### PR TITLE
Api businesslogic match serializer

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -8,6 +8,9 @@ up: build
 	docker compose --env-file .env.sample -f $(DOCKER_COMPOSE_FILE) up -d
 
 down:
+	docker compose --env-file .env.sample -f $(DOCKER_COMPOSE_FILE) down
+
+vdown:
 	docker compose --env-file .env.sample -f $(DOCKER_COMPOSE_FILE) down -v
 
 # 古いイメージを削除
@@ -18,4 +21,8 @@ image-prune:
 build:
 	docker compose --env-file .env.sample -f $(DOCKER_COMPOSE_FILE) build --no-cache
 
+# ボリュームを削除しないので、DBのデータが残る
 re:	down image-prune up
+
+# DBごと削除する
+cre: vdown image-prune up

--- a/api/conf/app_mtch/serializers.py
+++ b/api/conf/app_mtch/serializers.py
@@ -1,12 +1,67 @@
 from rest_framework import serializers
 from .models import Match, MatchDetail
+from tmt.models import Tournament, TournamentPlayer
+from plyr.models import Player
+
+STATUS_CHOICES = ['start', 'end']
+RESULT_CHOICES = ['win', 'lose', 'await']
 
 class MatchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Match
         fields = '__all__'
 
+    def validate(self, data):
+        # dataのフィールド欠如
+        if 'tournament_id' not in data:
+            raise serializers.ValidationError("key 'tournament_id' is required.")
+        if 'status' not in data:
+            raise serializers.ValidationError("key 'status' is required.")
+
+        # dataのフィールド値が期待と異なる
+        if data['status'] not in STATUS_CHOICES:
+            raise serializers.ValidationError("Match 'status' is invalid value.")
+
+        # dataのForeignKeyの値が、新しいデータの追加条件に適合していない
+        tournament = data.get('tournament_id')
+        if tournament.status == 'end':
+            raise serializers.ValidationError("Cannot create a match for a tournament that has already ended.")
+        
+        return data
+
 class MatchDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = MatchDetail
         fields = '__all__'
+
+    def validate(self, data):
+        # dataのフィールド欠如
+        if 'match_id' not in data:
+            raise serializers.ValidationError("key 'match_id' is required.")
+        if 'player_id' not in data:
+            raise serializers.ValidationError("key 'player_id' is required.")
+        if 'score' not in data:
+            raise serializers.ValidationError("key 'score' is required.")
+        if 'result' not in data:
+            raise serializers.ValidationError("key 'result' is required.")
+
+        # dataのフィールド値が期待と異なる
+        if data['score'] < 0:
+            raise serializers.ValidationError("Match 'score' can't set below 0.")
+        if data['result'] not in RESULT_CHOICES:
+            raise serializers.ValidationError("Matchdetail 'result' is invalid value.")
+
+        # dataのForeignKeyの値が、新しいデータの追加条件に適合していない
+        match = data.get('match_id')
+        if match.status == 'end':
+            raise serializers.ValidationError("Cannot create a matchdetail for a match that has already ended.")
+
+        tournament = match.tournament_id
+        player = data.get('player_id')
+        if not TournamentPlayer.objects.filter(tournament_id = tournament, player_id = player).exists():
+            raise serializers.ValidationError("This player is not part of Tournament player.")
+
+        if MatchDetail.objects.filter(match_id=match, player_id=player).exists():
+            raise serializers.ValidationError("Matchdetail is already exist.")
+        
+        return data


### PR DESCRIPTION
共通部分なのでさっさとプルリクエストしときます！
- Matchアプリのシリアライザーを更新（終了ステータスのトーナメントから新しいマッチを作成しようとしてないか、など）
- Makefileで``make re``した時にボリュームが消えないように変更

テスト
- トーナメントを作成（start, endステータスをそれぞれ）
- プレイヤーを登録
- トーナメントプレイヤーを登録
- mtch/mtch/ から新しいマッチを作成
- mtch/dtl/から新しいディティールを作成