### PR TITLE
Api businesslogic increment score

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,6 +8,9 @@ FROM python:3.9-slim AS base
 ## version of installed packages
 ARG PSYCOPG_VERSION=3.1.8
 ARG DJANGO_VERSION=4.2
+ARG DJANGO_REST_VERSION=3.15.2
+ARG GUNICORN_VERSION=23.0.0
+
 ## misc
 
 
@@ -33,7 +36,8 @@ RUN apt-get -y install \
     curl \
     lsof \
     tree
-## clean up to reduce the size of the image
+
+# clean up to reduce the size of the image
 RUN rm -rf /var/lib/apt/lists/*
 
 # Djangoとpsycopg(postgreSQL操作に必要)のインストール
@@ -42,8 +46,8 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade pip
 RUN pip install --no-cache-dir psycopg==${PSYCOPG_VERSION}
 RUN pip install --no-cache-dir Django==${DJANGO_VERSION}
-RUN pip install --no-cache-dir djangorestframework
-RUN pip install --no-cache-dir gunicorn
+RUN pip install --no-cache-dir djangorestframework==${DJANGO_REST_VERSION}
+RUN pip install --no-cache-dir gunicorn==${GUNICORN_VERSION}
 
 # Create a Django project
 RUN django-admin startproject ${DJANGO_PROJECT_NAME}
@@ -75,6 +79,9 @@ FROM base AS development_djangoserver
 
 # コンテナ内で"run"コマンドを実行すると、Djangoの開発サーバーが起動するようにaliasを設定
 RUN echo "alias run='python manage.py runserver 0.0.0.0:8000'" >> ~/.bashrc
+
+# コンテナ内で"test"コマンドを実行すると、Djangoのtestが実行できるようにaliasを設定
+RUN echo "alias test='python manage.py test'" >> ~/.bashrc
 
 ENTRYPOINT [ "/trans/entrypoint.sh" ]
 CMD ["sleep", "infinity"]

--- a/api/conf/app_mtch/serializers.py
+++ b/api/conf/app_mtch/serializers.py
@@ -61,7 +61,7 @@ class MatchDetailSerializer(serializers.ModelSerializer):
         if not TournamentPlayer.objects.filter(tournament_id = tournament, player_id = player).exists():
             raise serializers.ValidationError("This player is not part of Tournament player.")
 
-        if MatchDetail.objects.filter(match_id=match, player_id=player).exists():
+        if not self.instance and MatchDetail.objects.filter(match_id=match, player_id=player).exists():
             raise serializers.ValidationError("Matchdetail is already exist.")
         
         return data

--- a/api/conf/app_mtch/tests.py
+++ b/api/conf/app_mtch/tests.py
@@ -63,13 +63,13 @@ class MatchSerializerTests(BaseTestSetup):
         serializer = MatchSerializer(data={'tournament': 'invalid', 'status': 'start'})
         self.assertFalse(serializer.is_valid(), msg = serializer.errors)
     
-    # def test_ended_tournament(self):
-    #     serializer = MatchSerializer(data={'tournament_id': self.tournament2.id, 'status': 'start'})
-    #     self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+    def test_ended_tournament(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament2.id, 'status': 'start'})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
 
-    # def test_invalid_status(self):
-    #     serializer = MatchSerializer(data={'tournament': self.tournament1.id, 'status': 'invalid'})
-    #     self.assertFalse(serializer.is_valid())
+    def test_invalid_status(self):
+        serializer = MatchSerializer(data={'tournament': self.tournament1.id, 'status': 'invalid'})
+        self.assertFalse(serializer.is_valid())
 
     def test_overlength_status(self):
         serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': '12345678901'})
@@ -81,6 +81,35 @@ class MatchSerializerTests(BaseTestSetup):
 
 class MatchDetailSerializerTests(BaseTestSetup):
     def test_valid_data(self):
-        serializer = MatchDetailSerializer(data={'match_id': self.matches[1].id, 'player_id': self.players[1].id, 'score': 0, 'result': 'await'})
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[2].id, 'player_id': self.players[1].id, 'score': 0, 'result': 'await'})
         self.assertTrue(serializer.is_valid(), msg = serializer.errors)
 
+    def test_minus_score(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[2].id, 'player_id': self.players[2].id, 'score': -1, 'result': 'await'})
+        is_valid = serializer.is_valid()
+        print(serializer.errors) # もしエラーメッセージを出力したいときはこうする。なお、関数名のアルファベット順に出力される（defの定義順ではない）。
+        self.assertFalse(is_valid, msg = serializer.errors)
+
+    def test_invalid_result(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[2].id, 'player_id': self.players[2].id, 'score': 0, 'result': 'invalid'})
+        is_valid = serializer.is_valid()
+        print(serializer.errors)
+        self.assertFalse(is_valid, msg = serializer.errors)
+    
+    def test_ended_match(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[3].id, 'player_id': self.players[1].id, 'score': 0, 'result': 'await'})
+        is_valid = serializer.is_valid()
+        print(serializer.errors)
+        self.assertFalse(is_valid, msg = serializer.errors)
+    
+    def test_nonexistent_tournamentplayer(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[2].id, 'player_id': 9999, 'score': 0, 'result': 'await'})
+        is_valid = serializer.is_valid()
+        print(serializer.errors)
+        self.assertFalse(is_valid, msg = serializer.errors)
+
+    def test_existed_matchdetail(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[1].id, 'player_id': self.players[1].id, 'score': 0, 'result': 'await'})
+        is_valid = serializer.is_valid()
+        print(serializer.errors)
+        self.assertFalse(is_valid, msg = serializer.errors)

--- a/api/conf/app_mtch/tests.py
+++ b/api/conf/app_mtch/tests.py
@@ -1,0 +1,86 @@
+from django.test import TestCase
+
+from tmt.models import Tournament, TournamentPlayer
+from plyr.models import Player
+from .models import Match, MatchDetail
+from .serializers import MatchSerializer, MatchDetailSerializer
+
+class BaseTestSetup(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create tournaments
+        cls.tournament1 = Tournament.objects.create(id = 1, num_of_player = '2', status = 'start')
+        cls.tournament2 = Tournament.objects.create(id = 2, num_of_player = '4', status = 'end')
+        cls.tournament3 = Tournament.objects.create(id = 3, num_of_player = '8', status = 'start')
+
+        # Create players
+        cls.players = {}
+        for i in range(1, 9):
+            cls.players[i] = Player.objects.create(id = i, name = f'P{i}')
+        
+        # Create tournamentplayers
+        cls.tournamentplayers = {}
+        for i in range(1, 3):
+            cls.tournamentplayers[i] = TournamentPlayer.objects.create(player_id = cls.players[i], tournament_id = cls.tournament1, victory_count = 0, status = 'await')
+        for i in range(3, 7):
+            cls.tournamentplayers[i] = TournamentPlayer.objects.create(player_id = cls.players[i], tournament_id = cls.tournament2, victory_count = 0, status = 'await')
+        for i in range(1, 9):
+            cls.tournamentplayers[i] = TournamentPlayer.objects.create(player_id = cls.players[i], tournament_id = cls.tournament3, victory_count = 0, status = 'await')
+
+        # Create matches
+        cls.matches = {}
+        cls.matches[1] = Match.objects.create(tournament_id = cls.tournament1, status = 'start')
+        cls.matches[2] = Match.objects.create(tournament_id = cls.tournament3, status = 'start')
+        cls.matches[3] = Match.objects.create(tournament_id = cls.tournament1, status = 'end')
+
+        # Create matchdetails
+        cls.matchdetails = {}
+        cls.matchdetails[1] = MatchDetail.objects.create(match_id = cls.matches[1], player_id = cls.players[1], score = 0, result = 'await')
+        cls.matchdetails[2] = MatchDetail.objects.create(match_id = cls.matches[1], player_id = cls.players[2], score = 0, result = 'await')
+
+class MatchSerializerTests(BaseTestSetup):
+    def test_valid_data(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': 'start'})
+        self.assertTrue(serializer.is_valid(), msg = serializer.errors)
+
+    def test_extra_field(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': 'start', 'extra_field': 'value'})
+        self.assertTrue(serializer.is_valid(), msg = serializer.errors)
+    
+    def test_extra_value(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': ['start', 'end']})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+
+    def test_missing_field(self):
+        serializer = MatchSerializer(data={'status': 'start'})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+
+    def test_nonexistent_tournament(self):
+        serializer = MatchSerializer(data={'tournament_id': 9999, 'status': 'start'})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+
+    def test_literal_tournament(self):
+        serializer = MatchSerializer(data={'tournament': 'invalid', 'status': 'start'})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+    
+    # def test_ended_tournament(self):
+    #     serializer = MatchSerializer(data={'tournament_id': self.tournament2.id, 'status': 'start'})
+    #     self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+
+    # def test_invalid_status(self):
+    #     serializer = MatchSerializer(data={'tournament': self.tournament1.id, 'status': 'invalid'})
+    #     self.assertFalse(serializer.is_valid())
+
+    def test_overlength_status(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': '12345678901'})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+    
+    def test_empty_status(self):
+        serializer = MatchSerializer(data={'tournament_id': self.tournament1.id, 'status': ''})
+        self.assertFalse(serializer.is_valid(), msg = serializer.errors)
+
+class MatchDetailSerializerTests(BaseTestSetup):
+    def test_valid_data(self):
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[1].id, 'player_id': self.players[1].id, 'score': 0, 'result': 'await'})
+        self.assertTrue(serializer.is_valid(), msg = serializer.errors)
+

--- a/api/conf/app_mtch/tests.py
+++ b/api/conf/app_mtch/tests.py
@@ -5,9 +5,9 @@ from plyr.models import Player
 from .models import Match, MatchDetail
 from .serializers import MatchSerializer, MatchDetailSerializer
 
-from django.urls import reverse
-from rest_framework import status
-from rest_framework import APITestCase
+# from django.urls import reverse
+# from rest_framework import status
+# from rest_framework import APITestCase
 
 class BaseTestSetup(TestCase):
     @classmethod
@@ -36,6 +36,7 @@ class BaseTestSetup(TestCase):
         cls.matches[1] = Match.objects.create(tournament_id = cls.tournament1, status = 'start')
         cls.matches[2] = Match.objects.create(tournament_id = cls.tournament3, status = 'start')
         cls.matches[3] = Match.objects.create(tournament_id = cls.tournament1, status = 'end')
+        cls.matches[4] = Match.objects.create(tournament_id = cls.tournament2, status = 'start')
 
         # Create matchdetails
         cls.matchdetails = {}
@@ -107,7 +108,7 @@ class MatchDetailSerializerTests(BaseTestSetup):
         self.assertFalse(is_valid, msg = serializer.errors)
     
     def test_nonexistent_tournamentplayer(self):
-        serializer = MatchDetailSerializer(data={'match_id': self.matches[2].id, 'player_id': 9999, 'score': 0, 'result': 'await'})
+        serializer = MatchDetailSerializer(data={'match_id': self.matches[4].id, 'player_id': 1, 'score': 0, 'result': 'await'})
         is_valid = serializer.is_valid()
         print(serializer.errors)
         self.assertFalse(is_valid, msg = serializer.errors)

--- a/api/conf/app_mtch/tests.py
+++ b/api/conf/app_mtch/tests.py
@@ -126,7 +126,18 @@ class IncrementScoreViewTests(APITestCase, BaseTestSetup):
         data = {'matchdetail': {'match_id': self.matches[1].id, 'player_id': self.players[1].id}}
         response = self.client.put(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {1: {'player': {'name': 'P1'}, 'matchdetail': {'player_id': 1, 'match_id': 1, 'score': 1}}, 2: {'player': {'name': 'P2'}, 'matchdetail': {'player_id': 2, 'match_id': 1, 'score': 0}}})
+        expected_data = {
+            1: {
+                'player': {'name': 'P1'},
+                'matchdetail': {'player_id': 1, 'match_id': 1, 'score': 1}
+            },
+            2: {
+                'player': {'name': 'P2'},
+                'matchdetail': {'player_id': 2, 'match_id': 1, 'score': 0}
+            },
+            'match_end': False
+        }
+        self.assertEqual(response.data, expected_data)
     
     def test_increment_score_to_the_end(self):
         url = reverse('increment_score')
@@ -148,3 +159,4 @@ class IncrementScoreViewTests(APITestCase, BaseTestSetup):
         self.assertEqual(TournamentPlayer.objects.get(tournament_id = self.tournament1.id, player_id = self.players[2].id).status, 'win')
         self.tournament1.refresh_from_db()
         self.assertEqual(self.tournament1.status, 'end')
+        self.assertEqual(response.data['match_end'], True)

--- a/api/conf/app_mtch/tests.py
+++ b/api/conf/app_mtch/tests.py
@@ -5,6 +5,10 @@ from plyr.models import Player
 from .models import Match, MatchDetail
 from .serializers import MatchSerializer, MatchDetailSerializer
 
+from django.urls import reverse
+from rest_framework import status
+from rest_framework import APITestCase
+
 class BaseTestSetup(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/api/conf/app_mtch/urls.py
+++ b/api/conf/app_mtch/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import MatchViewSet, MatchDetailViewSet
+from .views import MatchViewSet, MatchDetailViewSet, IncrementScoreView
 
 router = DefaultRouter()
 router.register(r'mtch', MatchViewSet)
@@ -8,4 +8,5 @@ router.register(r'dtl', MatchDetailViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('iscr/', IncrementScoreView.as_view(), name='increment_score'),
 ]

--- a/api/conf/app_mtch/utils.py
+++ b/api/conf/app_mtch/utils.py
@@ -63,6 +63,13 @@ def create_ponggame_dataset(matchdetails_with_related):
     ponggame_dataset = {}
     for index, matchdetail in enumerate(matchdetails_with_related, start=1):
         ponggame_dataset[index] = create_ponggame_data(matchdetail)
+
+    # add key match_end
+    if (matchdetails_with_related[0].match_id.status == 'end'):
+        ponggame_dataset['match_end'] = True
+    else:
+        ponggame_dataset['match_end'] = False
+
     return ponggame_dataset
 
 # 対戦画面に必要なplayerごとのデータを作成する

--- a/api/conf/app_mtch/utils.py
+++ b/api/conf/app_mtch/utils.py
@@ -1,0 +1,102 @@
+from .models import Match, MatchDetail
+from .serializers import MatchDetailSerializer
+from rest_framework.exceptions import ValidationError
+from django.forms.models import model_to_dict
+from tmt.utils import ( update_tournamentplayer_status, increment_tournamentplayer_vcount )
+# ついでに作ってみたけど検証してない機能
+#
+# # Validate MatchDetail
+# # args: match_id: int, player_id: int, score: int, result: str
+# # return: MatchDetailのオブジェクト
+# def validate_matchdetail_data(match_id, player_id, score, result)
+#     matchdetail_data = {
+#         'match_id': match_id,
+#         'player_id': player_id,
+#         'score': score,
+#         'result': result
+#     }
+#     matchdetail_serializer = MatchDetailSerializer(data = matchdetail_serializer)
+#     if matchdetail_serializer.is_valid(raise_exception = True):
+#         return matchdetail_serializer.validated_data
+#     else:
+#         raise ValidationError(matchdetail_serializer.error)
+
+# # MatchDetailをDBに登録する
+# # args: MatchDetail(validated)のオブジェクト
+# # return: MatchDetailのインスタンス
+# def register_matchdetail(valid_matchdetail):
+#     return MatchDetail.objects.create(**valid_matchdetail)
+
+
+# MatchDetailのスコアをインクリメントする（DBへの保存はしない）
+# args: match_id: int, player_id: int
+# return: MatchDetailのオブジェクト
+def increment_score(match_id, player_id):
+    try:
+        matchdetail_instance = MatchDetail.objects.get(match_id = match_id, player_id = player_id)
+        matchdetail_instance.score += 1
+        return matchdetail_instance
+    except MatchDetail.DoesNotExist:
+        return None
+
+# MatchDetailのDB情報を更新する
+# args: MatchDetailのインスタンス
+# return: MatchDetailのインスタンス
+def validate_and_update_matchdetail(matchdetail_instance):
+    matchdetail_serializer = MatchDetailSerializer(instance = matchdetail_instance, data = model_to_dict(matchdetail_instance))
+
+    if matchdetail_serializer.is_valid(raise_exception = True):
+        return matchdetail_serializer.save()
+    else:
+        raise ValidationError(matchdetail_serializer.error)
+
+# MatchからMatchDetailとその関連データを取得する
+# args: match_id: int
+# return: MatchDetailのQuerySet (関連するPlayerおよびMatchデータを含む)
+def get_matchdetail_with_related_data(match_id):
+    return MatchDetail.objects.filter(match_id=match_id).select_related('player_id', 'match_id')
+
+# 対戦画面に必要なデータを作成する
+# args: MatchDetailのリスト
+# return: JSON形式のデータ
+def create_ponggame_dataset(matchdetails_with_related):
+    ponggame_dataset = {}
+    for index, matchdetail in enumerate(matchdetails_with_related, start=1):
+        ponggame_dataset[index] = create_ponggame_data(matchdetail)
+    return ponggame_dataset
+
+# 対戦画面に必要なplayerごとのデータを作成する
+# args: MatchDetailのインスタンス (関連するPlayerおよびMatchデータを含む方が良い）
+# return: JSON
+def create_ponggame_data(matchdetail):
+    return {
+        'player': {
+            'name': matchdetail.player_id.name
+        },
+        'matchdetail': {
+            'player_id': matchdetail.player_id.id,
+            'match_id': matchdetail.match_id.id,
+            'score': matchdetail.score
+        }
+    }
+
+def update_when_match_end(match_id, player_id, tournament_id):
+    opponent_player_id = get_opponent_player_id(match_id, player_id)
+    # Update MatchDetail result
+    update_matchdetail_result(match_id, player_id, 'win')
+    update_matchdetail_result(match_id, opponent_player_id, 'lose')
+    # Update Match status
+    update_match_status(match_id, 'end')
+    # Update TournamentPlayer status and victory_count
+    update_tournamentplayer_status(tournament_id, player_id, 'win')
+    update_tournamentplayer_status(tournament_id, opponent_player_id, 'lose')
+    increment_tournamentplayer_vcount(tournament_id, player_id)    
+
+def update_matchdetail_result(match_id, player_id, result):
+    MatchDetail.objects.filter(match_id = match_id, player_id = player_id).update(result = result)
+
+def get_opponent_player_id(match_id, player_id):
+    return MatchDetail.objects.filter(match_id = match_id).exclude(player_id = player_id).first().player_id.id
+
+def update_match_status(match_id, status):
+    Match.objects.filter(id = match_id).update(status = status)

--- a/api/conf/app_mtch/views.py
+++ b/api/conf/app_mtch/views.py
@@ -2,6 +2,17 @@ from rest_framework import viewsets
 from .models import Match, MatchDetail
 from .serializers import MatchSerializer, MatchDetailSerializer
 
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .utils import ( increment_score, validate_and_update_matchdetail,
+    get_matchdetail_with_related_data, update_when_match_end, create_ponggame_dataset )
+from rest_framework.exceptions import ValidationError
+from tmt.utils import ( update_tournamentplayer_status, increment_tournamentplayer_vcount, 
+    is_round_end, update_tournamentplayer_win_to_await, is_tournament_end, update_tournament_status )
+
+END_OF_GAME_SCORE = 10
+
 # start: ユースケースでは本来必要ないが、データの確認のために追加
 class MatchViewSet(viewsets.ModelViewSet):
     queryset = Match.objects.all()
@@ -11,3 +22,43 @@ class MatchDetailViewSet(viewsets.ModelViewSet):
     queryset = MatchDetail.objects.all()
     serializer_class = MatchDetailSerializer
 # end
+
+class IncrementScoreView(APIView):
+    def put(self, request):
+        match_id = request.data.get('matchdetail', {}).get('match_id')
+        player_id = request.data.get('matchdetail', {}).get('player_id')
+
+        if match_id is None or player_id is None:
+            return Response({"error": "match_id and player_id are required."}, status=status.HTTP_400_BAD_REQUEST)
+    
+        # スコアをインクリメントしたMatchDetailのインスタンスを取得
+        matchdetail_instance = increment_score(match_id, player_id)
+        if matchdetail_instance is None:
+            return Response({"error": "MatchDetail not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        # MatchDetailのDB情報を更新
+        try:
+            matchdetail = validate_and_update_matchdetail(matchdetail_instance)
+        except ValidationError as e:
+            return Response(e.detail, status=status.HTTP_400_BAD_REQUEST)
+
+        # 対戦が終了した時の処理
+        if matchdetail.score >= END_OF_GAME_SCORE:
+            # Prepare variables use several times
+            tournament_id = Match.objects.get(id=match_id).tournament_id
+            # シンプルなテーブル更新処理
+            update_when_match_end(match_id, player_id, tournament_id)
+
+            # トーナメントラウンドが終了した時の処理
+            if is_round_end(tournament_id):
+                update_tournamentplayer_win_to_await(tournament_id)
+
+            # トーナメントの終了判定
+            if is_tournament_end(tournament_id):
+                update_tournament_status(tournament_id.id, 'end')
+            else: # create_next_match(to be implemented)
+                pass
+
+        # Responseの作成
+        response_data = create_ponggame_dataset(get_matchdetail_with_related_data(match_id))
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/api/conf/app_tmt/utils.py
+++ b/api/conf/app_tmt/utils.py
@@ -1,6 +1,7 @@
-from .models import Tournament
+from .models import Tournament, TournamentPlayer
 from .serializers import TournamentSerializer
 from rest_framework.exceptions import ValidationError
+from django.db.models import F
 
 # Validate Tournament
 # args: トーナメントの参加人数, トーナメントのステータス
@@ -21,3 +22,36 @@ def validate_tournament(num_of_player, status):
 # return: Tournamentのオブジェクト
 def register_tournament(valid_tournament):
     return Tournament.objects.create(**valid_tournament)
+
+# TournamentPlayerのステータスを更新する
+def update_tournamentplayer_status(tournament_id, player_id, status):
+    TournamentPlayer.objects.filter(tournament_id = tournament_id, player_id = player_id).update(status = status)
+
+# TournamentPlayerのvcountをインクリメントする
+def increment_tournamentplayer_vcount(tournament_id, player_id):
+    TournamentPlayer.objects.filter(tournament_id = tournament_id, player_id = player_id).update(victory_count = F('victory_count') + 1)
+
+# TournamentPlayerでラウンドが終了したかどうかを判定する
+def is_round_end(tournament_id):
+    tournamentplayers = TournamentPlayer.objects.filter(tournament_id = tournament_id)
+    # awaitステータスのプレイヤーがいたらラウンド終了ではない
+    if tournamentplayers.filter(status = 'await').exists():
+        return False
+    return True
+
+# TournamentPlayerのwinをawaitに変更する
+def update_tournamentplayer_win_to_await(tournament_id):
+    TournamentPlayer.objects.filter(tournament_id = tournament_id, status = 'win').update(status = 'await')
+
+# Tournamentがが終了したかを判定する
+def is_tournament_end(tournament_id):
+    tournamentplayers = TournamentPlayer.objects.filter(tournament_id = tournament_id)
+    # awaitステータスのプレイヤー1人だけの場合はトーナメント終了
+    if tournamentplayers.filter(status = 'await').count() == 1:
+        tournamentplayers.filter(status = 'await').update(status = 'win')
+        return True
+    return False
+
+# Tournamentのstatusを更新する
+def update_tournament_status(tournament_id, status):
+    Tournament.objects.filter(id = tournament_id).update(status = status)


### PR DESCRIPTION
**Testの方法**

1. コンテナ内で、``test mtch`` (これで網羅してるつもり)
2. ブラウザのエンドポイント(api/mtch/iscr)からリクエストデータを送信（前準備のDBデータの投入が必要）

**やったこと**

1. MatchDetailまでがある状態で、apiエンドポイントからPUTリクエストが来た時の処理（内部データの更新とレスポンス）
2. １つの試合が終了点に達した時の内部処理
3. トーナメントの１つのラウンド（全ての1回戦など）が終了した時の内部処理
4. トーナメントが全て終了した時（優勝が決まった）の内部処理

**やってないこと**（sinagakiくんパートで作成する関数の拝借）

1. views.pyに次のマッチを作成する関数（create_next_tmt_match）を記述すること