### PR TITLE
Update nginx conf

### DIFF
--- a/reverseproxy/nginx.conf
+++ b/reverseproxy/nginx.conf
@@ -1,19 +1,19 @@
 worker_processes 1;
 
-user nobody nogroup;  # Nginx のプロセスを実行するユーザーとグループを 'nobody' に設定します。セキュリティの観点から、特権の少ないユーザーで実行します。
-error_log /var/log/nginx/error.log warn;  # エラーログの出力先を指定し、ログレベルを 'warn' に設定します。警告レベル以上のメッセージが記録されます。
-pid /var/run/nginx.pid;  # Nginx のプロセス ID を保存するファイルのパスを指定します。プロセス管理に使用されます。
+user nobody nogroup;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
 
 events {
     worker_connections 1024;
 }
 
 http {
-    include mime.types;  # MIME タイプを定義したファイルをインクルードし、ファイルの拡張子に応じた適切なコンテンツタイプを設定します。
-    default_type application/octet-stream;  # デフォルトのコンテンツタイプを設定します。指定がない場合に使用されます。
-    access_log /var/log/nginx/access.log combined;  # アクセスログの出力先とログフォーマットを設定します。'combined' は一般的なログフォーマットです。
-    sendfile on;  # ファイルの転送を効率化するために 'sendfile' を有効にします。ファイル転送のパフォーマンスを向上させます。
-
+    server_tokens off; # version情報を隠蔽
+    include mime.types;
+    default_type application/octet-stream;
+    access_log /var/log/nginx/access.log combinedi flush=5s; #5秒ごとに出力
+    sendfile on;
 
     upstream frontend {
         server web:5173;
@@ -44,9 +44,14 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_buffering off; #リアルタイム性を重視する
-            proxy_ignore_client_abort on; #クライアントによる中断を無視して処理を続行(切断されても処理を実行)
+            proxy_buffering off; #リアルタイム性を重視するためbufの中止
+            proxy_ignore_client_abort on; #切断対策
         }
+
+        location ~ /\.$ {
+            deny all;
+        }
+
     }
 
     server {

--- a/reverseproxy/nginx.conf
+++ b/reverseproxy/nginx.conf
@@ -1,8 +1,20 @@
+worker_processes 1;
+
+user nobody nogroup;  # Nginx のプロセスを実行するユーザーとグループを 'nobody' に設定します。セキュリティの観点から、特権の少ないユーザーで実行します。
+error_log /var/log/nginx/error.log warn;  # エラーログの出力先を指定し、ログレベルを 'warn' に設定します。警告レベル以上のメッセージが記録されます。
+pid /var/run/nginx.pid;  # Nginx のプロセス ID を保存するファイルのパスを指定します。プロセス管理に使用されます。
+
 events {
     worker_connections 1024;
 }
 
 http {
+    include mime.types;  # MIME タイプを定義したファイルをインクルードし、ファイルの拡張子に応じた適切なコンテンツタイプを設定します。
+    default_type application/octet-stream;  # デフォルトのコンテンツタイプを設定します。指定がない場合に使用されます。
+    access_log /var/log/nginx/access.log combined;  # アクセスログの出力先とログフォーマットを設定します。'combined' は一般的なログフォーマットです。
+    sendfile on;  # ファイルの転送を効率化するために 'sendfile' を有効にします。ファイル転送のパフォーマンスを向上させます。
+
+
     upstream frontend {
         server web:5173;
     }
@@ -13,10 +25,8 @@ http {
 
     server {
         listen 443 ssl;
-
-        ssl_certificate /etc/ssl/certs/ca-certificates.pem
-        ssl_certificate_key /etc/ssl/private/ca-certificates.pem
-
+        ssl_certificate /etc/ssl/certs/ca-certificates.pem;
+        ssl_certificate_key /etc/ssl/private/ca-certificates.pem;
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers HIGH:!aNULL:!MD5;
 
@@ -34,12 +44,13 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_buffering off; #リアルタイム性を重視する
+            proxy_ignore_client_abort on; #クライアントによる中断を無視して処理を続行(切断されても処理を実行)
         }
     }
-    
+
     server {
         listen 80;
-
         return 301 https://$host$request_uri;
     }
 }


### PR DESCRIPTION
主にやったこと
- エラーとかを吐かせてみるlog系の設定
- セキュリティ系userのレベルとか、.ファイルにアクセスできないとか、nginxのversion情報隠すとか
- apiのバッファリングの中止と切断されても処理を完了するように変更

チャッピーに解説書かせてみた。
```
 worker_processes 1;

user nobody nogroup;
error_log /var/log/nginx/error.log warn;
pid /var/run/nginx.pid;

events {
    worker_connections 1024;  # 各ワーカープロセスが同時に処理できる接続の最大数
}

http {
    server_tokens off;  # Nginx のバージョン情報を隠蔽し、セキュリティを向上させる
    include mime.types;  # MIME タイプの設定ファイルをインクルード
    default_type application/octet-stream;  # MIME タイプが不明なファイルに対するデフォルトの MIME タイプ
    access_log /var/log/nginx/access.log combined flush=5s;  # アクセスログの出力先、ログを5秒ごとにフラッシュ
    sendfile on;  # ファイル転送をいい感じにしてくれる

    upstream frontend {
        server web:5173;  # `frontend` サーバーの定義。リクエストを `web:5173` に転送
    }

    upstream backend {
        server api:8000;  # `backend` サーバーの定義。リクエストを `api:8000` に転送
    }

    server {
        listen 443 ssl;  # HTTPS 通信のためにポート 443 でリッスン
        ssl_certificate /etc/ssl/certs/ca-certificates.pem;  # SSL 証明書のパス
        ssl_certificate_key /etc/ssl/private/ca-certificates.pem;  # SSL 証明書の秘密鍵のパス
        ssl_protocols TLSv1.2 TLSv1.3;  # 使用する TLS プロトコルを指定
        ssl_ciphers HIGH:!aNULL:!MD5;  # 使用する暗号スイートを設定。強力な暗号化を使用

        location / {
            proxy_pass http://frontend;  # リクエストを `frontend` サーバーにプロキシ
            proxy_set_header Host $host;  # クライアントの Host ヘッダーを転送
            proxy_set_header X-Real-IP $remote_addr;  # クライアントの IP アドレスを転送
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For ヘッダーを追加
            proxy_set_header X-Forwarded-Proto $scheme;  # X-Forwarded-Proto ヘッダーを追加
        }

        location /api/ {
            proxy_pass http://backend;  # リクエストを `backend` サーバーにプロキシ
            proxy_set_header Host $host;  # クライアントの Host ヘッダーを転送
            proxy_set_header X-Real-IP $remote_addr;  # クライアントの IP アドレスを転送
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For ヘッダーを追加
            proxy_set_header X-Forwarded-Proto $scheme;  # X-Forwarded-Proto ヘッダーを追加
            proxy_buffering off;  # リアルタイム性を重視するためプロキシバッファリングを無効化
            proxy_ignore_client_abort on;  # クライアントがリクエストを中断しても、サーバーはリクエストの処理を続ける
        }

        location ~ /\.$ {
            deny all;  # ファイルパスが `/.` で終わるリクエストを拒否
        }
    }

    server {
        listen 80;  # HTTP 通信のためにポート 80 でリッスン
        return 301 https://$host$request_uri;  # HTTP リクエストを HTTPS にリダイレクト
    }
}

```