### PR TITLE
Api add database rollback function

### DIFF
--- a/api/conf/app_match/views.py
+++ b/api/conf/app_match/views.py
@@ -1,19 +1,19 @@
 from rest_framework import viewsets
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.exceptions import ValidationError
+from django.utils.decorators import method_decorator
+from django.db import transaction
+
 from .models import Match, MatchDetail
 from tournament.models import Tournament
 from .serializers import MatchSerializer, MatchDetailSerializer
-
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
 from .utils import ( increment_score, validate_and_update_matchdetail,
     get_matchdetail_with_related_data, update_when_match_end, create_ponggame_dataset )
-from rest_framework.exceptions import ValidationError
 from tournament.utils import ( update_tournamentplayer_status, increment_tournamentplayer_vcount, 
     is_round_end, update_tournamentplayer_win_to_await, is_tournament_end, update_tournament_status,
     create_next_tournament_match )
-
-from django.utils.decorators import method_decorator
 from utils.decorators import admin_only
 
 END_OF_GAME_SCORE = 10
@@ -35,17 +35,17 @@ class LocalMatchView(APIView):
         cookie_tournament_id = request.COOKIES.get('tournament_id')
         # Is there a match with the start status?
         if cookie_tournament_id is None:
-            return Response({"error": "tournament_id is required."}, status=status.HTTP_400_NOT_FOUND)
+            return Response({"error": "tournament_id is required."}, status = status.HTTP_404_NOT_FOUND)
         try:
             tournament = Tournament.objects.get(id=cookie_tournament_id)
         except Tournament.DoesNotExist:
-            return Response({"error": "Tournament not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "Tournament not found."}, status = status.HTTP_404_NOT_FOUND)
         if tournament.status != 'start':
-            return Response({"error": "Tournament is over."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": "Tournament is over."}, status = status.HTTP_400_BAD_REQUEST)
         displayable_match_id = Match.objects.get(tournament_id = cookie_tournament_id, status = 'start').id
 
         if displayable_match_id is None:
-            return Response({"error": "Match with start status not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "Match with start status not found."}, status = status.HTTP_404_NOT_FOUND)
         response_data = create_ponggame_dataset(get_matchdetail_with_related_data(displayable_match_id))
         return Response(response_data, status=status.HTTP_200_OK)
 
@@ -55,42 +55,48 @@ class LocalScoreView(APIView):
         player_id = request.data.get('player_id')
 
         if match_id is None or player_id is None:
-            return Response({"error": "match_id and player_id are required."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": "match_id and player_id are required."}, status = status.HTTP_400_BAD_REQUEST)
         try:
             match = Match.objects.get(id=match_id)
         except Match.DoesNotExist:
-            return Response({"error": "Match not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "Match not found."}, status = status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            return Response({"error": str(e)}, status = status.HTTP_500_INTERNAL_SERVER_ERROR)
         if match.status == 'end':
-            return Response({"error": "Match is over."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": "Match is over."}, status = status.HTTP_400_BAD_REQUEST)
 
         # スコアをインクリメントしたMatchDetailのインスタンスを取得
         matchdetail_instance = increment_score(match_id, player_id)
         if matchdetail_instance is None:
-            return Response({"error": "MatchDetail not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "MatchDetail not found."}, status = status.HTTP_404_NOT_FOUND)
 
         # MatchDetailのDB情報を更新
         try:
-            matchdetail = validate_and_update_matchdetail(matchdetail_instance)
+            with transaction.atomic():
+                matchdetail = validate_and_update_matchdetail(matchdetail_instance)
+
+                # 対戦が終了した時の処理
+                if matchdetail.score >= END_OF_GAME_SCORE:
+                    # Prepare variables use several times
+                    tournament_id = Match.objects.get(id=match_id).tournament_id
+                    # シンプルなテーブル更新処理
+                    update_when_match_end(match_id, player_id, tournament_id)
+
+                    # トーナメントラウンドが終了した時の処理
+                    if is_round_end(tournament_id):
+                        update_tournamentplayer_win_to_await(tournament_id)
+
+                    # トーナメントの終了判定
+                    if is_tournament_end(tournament_id):
+                        update_tournament_status(tournament_id.id, 'end')
+                    else:
+                        create_next_tournament_match(tournament_id)
+
+            # Responseの作成
+            response_data = create_ponggame_dataset(get_matchdetail_with_related_data(match_id))
+            return Response(response_data, status=status.HTTP_200_OK)
+
         except ValidationError as e:
-            return Response(e.detail, status=status.HTTP_400_BAD_REQUEST)
-
-        # 対戦が終了した時の処理
-        if matchdetail.score >= END_OF_GAME_SCORE:
-            # Prepare variables use several times
-            tournament_id = Match.objects.get(id=match_id).tournament_id
-            # シンプルなテーブル更新処理
-            update_when_match_end(match_id, player_id, tournament_id)
-
-            # トーナメントラウンドが終了した時の処理
-            if is_round_end(tournament_id):
-                update_tournamentplayer_win_to_await(tournament_id)
-
-            # トーナメントの終了判定
-            if is_tournament_end(tournament_id):
-                update_tournament_status(tournament_id.id, 'end')
-            else:
-                create_next_tournament_match(tournament_id)
-
-        # Responseの作成
-        response_data = create_ponggame_dataset(get_matchdetail_with_related_data(match_id))
-        return Response(response_data, status=status.HTTP_200_OK)
+            return Response(e.detail, status = status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response({"error": str(e)}, status = status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/api/conf/app_tournament/views.py
+++ b/api/conf/app_tournament/views.py
@@ -32,7 +32,7 @@ class LocalTournamentView(APIView):
         cookie_tournament_id = request.COOKIES.get('tournament_id')
         # Is there a match with the start status?
         if cookie_tournament_id is None:
-            return Response({"error": "tournament_id is required."}, status=status.HTTP_400_NOT_FOUND)
+            return Response({"error": "tournament_id is required."}, status=status.HTTP_400_BAD_REQUEST)
         try:
             tournament = Tournament.objects.get(id=cookie_tournament_id)
         except Tournament.DoesNotExist:

--- a/api/conf/app_tournament/views.py
+++ b/api/conf/app_tournament/views.py
@@ -1,18 +1,17 @@
 import random
 
 from rest_framework import viewsets
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from django.utils.decorators import method_decorator
+from django.db import transaction
+
 from .models import Tournament, TournamentPlayer
 from .serializers import TournamentSerializer, TournamentPlayerSerializer
-from rest_framework.exceptions import ValidationError
-
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
-from player.utils import validate_players, register_players
 from .utils import create_tournament, create_next_tournament_match, create_tournament_dataset, get_tournamentplayer_with_related_data
-from player.serializers import PlayerSerializer
-
-from django.utils.decorators import method_decorator
+from player.utils import validate_players, register_players
 from utils.decorators import admin_only
 
 # start: ユースケースでは本来必要ないが、データの確認のために追加
@@ -32,11 +31,11 @@ class LocalTournamentView(APIView):
         cookie_tournament_id = request.COOKIES.get('tournament_id')
         # Is there a match with the start status?
         if cookie_tournament_id is None:
-            return Response({"error": "tournament_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": "tournament_id is required."}, status = status.HTTP_400_BAD_REQUEST)
         try:
             tournament = Tournament.objects.get(id=cookie_tournament_id)
         except Tournament.DoesNotExist:
-            return Response({"error": "Tournament not found."}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": "Tournament not found."}, status = status.HTTP_404_NOT_FOUND)
         
         response_data = create_tournament_dataset(get_tournamentplayer_with_related_data(tournament.id))
         return Response(response_data, status=status.HTTP_200_OK)
@@ -44,25 +43,23 @@ class LocalTournamentView(APIView):
     def post(self, request):
         player_names = request.data.get('players', [])
         if not player_names:
-            return Response("player names are required.", status=status.HTTP_400_BAD_REQUEST)
+            return Response("player names are required.", status = status.HTTP_400_BAD_REQUEST)
         # プレイヤー名をシャッフル
         random.shuffle(player_names)
-        # PlayerをDBに登録
-        try:
-            players = register_players(validate_players(player_names))
-        except ValidationError as e:
-            return Response(e.detail, status = status.HTTP_400_BAD_REQUEST)
-        
-        # Tournament, TournamentPlayerをDBに登録
-        try:
-            tournament, tournament_players = create_tournament(players)
-        except ValidationError as e:
-            return Response(e.detail, status = status.HTTP_400_BAD_REQUEST)
 
         try:
-            create_next_tournament_match(tournament.id)
+            with transaction.atomic():
+                # PlayerをDBに登録
+                players = register_players(validate_players(player_names))
+                # Tournament, TournamentPlayerをDBに登録
+                tournament, tournament_players = create_tournament(players)
+                # Match, MatchDetailをDBに登録
+                create_next_tournament_match(tournament.id)
+            
+            response_data = create_tournament_dataset(get_tournamentplayer_with_related_data(tournament.id))
+            return Response(response_data, status = status.HTTP_201_CREATED)
+
         except ValidationError as e:
             return Response(e.detail, status = status.HTTP_400_BAD_REQUEST)
-
-        response_data = create_tournament_dataset(get_tournamentplayer_with_related_data(tournament.id))
-        return Response(response_data, status = status.HTTP_201_CREATED)
+        except Exception as e:
+            return Response({"error": str(e)}, status = status.HTTP_500_INTERNAL_SERVER_ERROR)        


### PR DESCRIPTION
**Testの方法**

- トーナメント参加できない人数で、/api/tournaments/local/からPOSTして、DBにプレイヤー名などが残らないこと
- test ~~がすべて成功すること(今回の変更点のテストは準備していません)

**やったこと**

- ビジネスロジックで失敗した時に、DBに書き込んだ内容をロールバックする処理の追加
- /api/matches/score/へのPATCHでもロールバックを追加したが、テストのやり方が思い浮かばなかったのでロールバックのテストはしてません