### PR TITLE
dockerignore修正案

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,13 +1,8 @@
 # ignore all .env file to protect sensitive data
-*/.env
+**/.env
 
 # ignore all .gitignore file to protect sensitive data
-*/.gitignore
+**/.gitignore
 
 # ignore all .DS_Store file to protect sensitive data and avoid cache
-*/.DS_Store
-
-# ignore all other Container files
-./reverseproxy/*
-./static-builder/*
-./rdbms/*
+**/.DS_Store


### PR DESCRIPTION
修正したこと
1. ビルドコンテクストとは関係のないディレクトリのignore
./reverseproxy
./rdbms
./static-builder
は、api/配下（ビルドコンテクスト）にないので、関係ないと判断し削除しました。

2. 全てのディレクトリからターゲットのファイルをignoreする
\*/filenameだと、ビルドコンテクストから１レベル下のみしかチェックしませんが、全てのディレクトリをチェックする意図があれば\*\*/filenameです。（意図していたのが前者でしたらすみません。）

[参考](https://shisho.dev/blog/posts/how-to-use-dockerignore/)
確認お願いします！