### PR TITLE
static-builder配下に.dockerignore追加

### DIFF
--- a/static-builder/.dockerignore
+++ b/static-builder/.dockerignore
@@ -1,0 +1,8 @@
+# ignore all .env file to protect sensitive data
+**/.env
+
+# ignore all .gitignore file to protect sensitive data
+**/.gitignore
+
+# ignore all .DS_Store file to protect sensitive data and avoid cache
+**/.DS_Store


### PR DESCRIPTION
Dockerfileを使ってビルドする時に.dockerignoreを使いますが、今のとこDockerfileがありそうなのがapiとstatic-builder配下だけっぽかったので、とりあえずそこだけ.dockerignore追加しました

[参考](https://www.reddit.com/r/docker/comments/18b8gg0/dockerignore_being_ignored_by_dockercompose_no/?rdt=54275)