### PR TITLE
Add use location use navigation hooks

### DIFF
--- a/static-builder/src/js/libs/router.js
+++ b/static-builder/src/js/libs/router.js
@@ -1,7 +1,9 @@
 import { Teact } from '@/js/libs/teact'
 
 const routes = []
-let setCurrentPath = () => {}
+let setCurrentPath = () => {
+  return
+}
 let currentState = {}
 
 export function Router() {
@@ -58,7 +60,7 @@ export function useNavigate() {
   }
 }
 
-window.addEventListener('popstate', (event) => {
+window.addEventListener('popstate', event => {
   currentState = event.state || {}
   setCurrentPath(window.location.pathname, currentState)
 })

--- a/static-builder/src/js/libs/router.js
+++ b/static-builder/src/js/libs/router.js
@@ -8,9 +8,14 @@ export function Router() {
   setCurrentPath = setPath
 
   const route = routes.find(r => r.path === currentPath)
-  return route
-    ? route.component
-    : Teact.createElement('h1', null, '404 Not Found')
+  if (!route) {
+    return Teact.createElement('h1', null, '404 Not Found')
+  }
+
+  if (route.component instanceof Function) {
+    return Teact.createElement(route.component)
+  }
+  return route.component
 }
 
 export function Route({ path, component }) {

--- a/static-builder/src/js/libs/router.js
+++ b/static-builder/src/js/libs/router.js
@@ -42,7 +42,7 @@ export function Link({ to, className, children, state }) {
   )
 }
 
-export function navigate(to, state = {}) {
+function navigate(to, state = {}) {
   window.history.pushState(state, '', to)
   currentState = state
   setCurrentPath(to, state)

--- a/static-builder/src/js/libs/teact.js
+++ b/static-builder/src/js/libs/teact.js
@@ -109,6 +109,7 @@ function commitWork(fiber) {
     updateDom(fiber.dom, fiber.alternate.props, fiber.props)
   } else if (fiber.effectTag === 'DELETION') {
     commitDeletion(fiber, domParent)
+    return
   }
 
   commitWork(fiber.child)

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -5,17 +5,13 @@ import { Home } from '@/js/pages/Home'
 
 // TODO About ページのrouteを設定したら消す
 const Tournament = () => {
-  const loc= useLocation();
+  const loc = useLocation()
 
   Teact.useEffect(() => {
     console.log(loc)
   }, [])
 
-  return Teact.createElement(
-    'h1',
-    null,
-    'tournament'
-  )
+  return Teact.createElement('h1', null, 'tournament')
 }
 
 function App() {
@@ -31,8 +27,8 @@ function App() {
     }),
     Route({
       path: '/tournament',
-      component: Tournament
-    })
+      component: Tournament,
+    }),
   )
 }
 

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -1,11 +1,20 @@
 import '@/scss/styles.scss'
-import { Route, Router } from '@/js/libs/router'
+import { Route, Router, Link } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 import { Home } from '@/js/pages/Home'
 
+// TODO About ページのrouteを設定したら消す
+const Tournament = () => {
+  return Teact.createElement(
+    'h1',
+    null,
+    'tournament'
+  )
+}
+
 function App() {
   return Router(
-    Route({ path: '/', component: Home() }),
+    Route({ path: '/', component: Home }),
     Route({
       path: '/about',
       component: Teact.createElement('h1', null, 'About'),
@@ -14,6 +23,10 @@ function App() {
       path: '/contact',
       component: Teact.createElement('h1', null, 'Contact'),
     }),
+    Route({
+      path: '/tournament',
+      component: Tournament
+    })
   )
 }
 

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -1,10 +1,16 @@
 import '@/scss/styles.scss'
-import { Route, Router, Link } from '@/js/libs/router'
+import { Route, Router, useLocation } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 import { Home } from '@/js/pages/Home'
 
 // TODO About ページのrouteを設定したら消す
 const Tournament = () => {
+  const loc= useLocation();
+
+  Teact.useEffect(() => {
+    console.log(loc)
+  }, [])
+
   return Teact.createElement(
     'h1',
     null,

--- a/static-builder/src/js/pages/Home.js
+++ b/static-builder/src/js/pages/Home.js
@@ -21,10 +21,13 @@ export const Home = () => {
         DefaultButton({ text: '１人対戦', onClick: () => navigate('/game') }), // TBD
         DefaultButton({
           text: 'トーナメント',
-          onClick: () => navigate('/tournament', {player: {
-            name: 'John',
-            score: 0,
-          }}),
+          onClick: () =>
+            navigate('/tournament', {
+              player: {
+                name: 'John',
+                score: 0,
+              },
+            }),
         }), // TBD
       ),
     ),

--- a/static-builder/src/js/pages/Home.js
+++ b/static-builder/src/js/pages/Home.js
@@ -19,7 +19,10 @@ export const Home = () => {
         DefaultButton({ text: '１人対戦', onClick: () => navigate('/game') }), // TBD
         DefaultButton({
           text: 'トーナメント',
-          onClick: () => navigate('/tournament'),
+          onClick: () => navigate('/tournament', {player: {
+            name: 'John',
+            score: 0,
+          }}),
         }), // TBD
       ),
     ),

--- a/static-builder/src/js/pages/Home.js
+++ b/static-builder/src/js/pages/Home.js
@@ -1,9 +1,11 @@
 import { DefaultButton } from '@/js/components/ui/button'
 import { BaseLayout } from '@/js/layouts/BaseLayout'
-import { navigate } from '@/js/libs/router'
+import { useNavigate } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 
 export const Home = () => {
+  const navigate = useNavigate()
+
   return BaseLayout(
     Teact.createElement(
       'div',


### PR DESCRIPTION
ページ遷移時に値を渡せるようにする
差分検出で予期しない動作してたとこ直す

<img width="1440" alt="Screenshot 2024-09-16 at 23 17 15" src="https://github.com/user-attachments/assets/434781bc-3626-4419-8208-5a75a1679022">

- [ ] Homeからトーナメントページに飛ぶときに値を取得できる
- [ ] 既存のページで期待通りの動作する