### PR TITLE
add useEffect cleanup func

### DIFF
--- a/static-builder/src/js/libs/teact.js
+++ b/static-builder/src/js/libs/teact.js
@@ -297,38 +297,38 @@ function useState(initial) {
 }
 
 function useEffect(callback, deps) {
-  const oldHook = wipFiber.alternate?.hooks?.[hookIndex];
+  const oldHook = wipFiber.alternate?.hooks?.[hookIndex]
   const hook = {
     deps,
     cleanup: null,
-  };
+  }
 
-  const hasChanged = !oldHook?.deps ||
-    oldHook.deps.some((dep, index) => dep !== deps[index]);
+  const hasChanged =
+    !oldHook?.deps || oldHook.deps.some((dep, index) => dep !== deps[index])
 
   if (hasChanged) {
     if (oldHook && typeof oldHook.cleanup === 'function') {
       wipFiber.effects.push(() => {
-        oldHook.cleanup();
-        const cleanup = callback();
+        oldHook.cleanup()
+        const cleanup = callback()
         if (typeof cleanup === 'function') {
-          hook.cleanup = cleanup;
+          hook.cleanup = cleanup
         }
-      });
+      })
     } else {
       wipFiber.effects.push(() => {
-        const cleanup = callback();
+        const cleanup = callback()
         if (typeof cleanup === 'function') {
-          hook.cleanup = cleanup;
+          hook.cleanup = cleanup
         }
-      });
+      })
     }
   } else {
-    hook.cleanup = oldHook.cleanup;
+    hook.cleanup = oldHook.cleanup
   }
 
-  wipFiber.hooks.push(hook);
-  hookIndex++;
+  wipFiber.hooks.push(hook)
+  hookIndex++
 }
 
 function useCallback(callback, deps) {

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -3,8 +3,8 @@ import { Route, Router } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 import { Home } from '@/js/pages/Home'
 import { InputAlias } from '@/js/pages/InputAlias'
-import { Tournament } from '@/js/pages/Tournament'
 import { Pong } from '@/js/pages/Pong'
+import { Tournament } from '@/js/pages/Tournament'
 
 function App() {
   return Router(

--- a/static-builder/src/js/pages/Home.js
+++ b/static-builder/src/js/pages/Home.js
@@ -1,9 +1,9 @@
 import { DefaultButton } from '@/js/components/ui/button'
+import { tournamentsApi } from '@/js/infrastructures/api/tournamentApi'
+import { cookie } from '@/js/infrastructures/cookie/cookie'
 import { BaseLayout } from '@/js/layouts/BaseLayout'
 import { useNavigate } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
-import { tournamentsApi } from '@/js/infrastructures/api/tournamentApi'
-import { cookie } from '@/js/infrastructures/cookie/cookie'
 
 export const Home = () => {
   const navigate = useNavigate()

--- a/static-builder/src/js/pages/InputAlias.js
+++ b/static-builder/src/js/pages/InputAlias.js
@@ -1,10 +1,10 @@
 import '@/scss/styles.scss'
 import { DefaultButton } from '@/js/components/ui/button'
-import { BaseLayout } from '@/js/layouts/BaseLayout'
-import { Teact } from '@/js/libs/teact'
-import { useNavigate, useLocation } from '../libs/router'
 import { tournamentsApi } from '@/js/infrastructures/api/tournamentApi'
 import { cookie } from '@/js/infrastructures/cookie/cookie'
+import { BaseLayout } from '@/js/layouts/BaseLayout'
+import { Teact } from '@/js/libs/teact'
+import { useLocation, useNavigate } from '../libs/router'
 
 function handleSubmit(event) {
   const navigate = useNavigate()

--- a/static-builder/src/js/pages/Pong.js
+++ b/static-builder/src/js/pages/Pong.js
@@ -1,12 +1,10 @@
 import '@/scss/styles.scss'
-import { BaseLayout } from '@/js/layouts/BaseLayout'
-import { Teact } from '@/js/libs/teact'
-import { useNavigate, useLocation } from '@/js/libs/router'
 import { DefaultButton } from '@/js/components/ui/button'
 import { api } from '@/js/infrastructures/api/fetch'
 import { tournamentsApi } from '@/js/infrastructures/api/tournamentApi'
-
-
+import { BaseLayout } from '@/js/layouts/BaseLayout'
+import { useLocation, useNavigate } from '@/js/libs/router'
+import { Teact } from '@/js/libs/teact'
 
 function fetchTournament(endMatch) {
   if (!endMatch) {
@@ -73,8 +71,6 @@ const Pong = () => {
     startButton.textContent = 'ボール発射'
     document.getElementById('utilButton').appendChild(startButton)
     startButton.addEventListener('click', startPong)
-
-
 
     function drawRect(x, y, width, height, color) {
       context.fillStyle = color
@@ -251,11 +247,12 @@ const Pong = () => {
 
     function startPong(e) {
       if (canStart === true) {
-        ballSpeedX = (Math.random() * 0.5 + 0.5) * (Math.random() < 0.5 ? 1 : -1)
-        ballSpeedY = Math.random( ) - 0.5
+        ballSpeedX =
+          (Math.random() * 0.5 + 0.5) * (Math.random() < 0.5 ? 1 : -1)
+        ballSpeedY = Math.random() - 0.5
         const normalizer = Math.sqrt(ballSpeedX ** 2 + ballSpeedY ** 2)
-        ballSpeedX =  ballSpeedX * 7 / normalizer
-        ballSpeedY =  ballSpeedY * 7 / normalizer
+        ballSpeedX = (ballSpeedX * 7) / normalizer
+        ballSpeedY = (ballSpeedY * 7) / normalizer
         console.log(ballSpeedX, ballSpeedY)
         canStart = false
       }
@@ -326,12 +323,12 @@ const Pong = () => {
       Teact.createElement(
         'div',
         { className: 'd-grid gap-2 col-3 mx-auto', id: 'utilButton' },
-        endMatch ?
-        DefaultButton({
-          text: 'トーナメント画面へ',
-          onClick: () => fetchTournament(endMatch),
-        })
-        : null,
+        endMatch
+          ? DefaultButton({
+              text: 'トーナメント画面へ',
+              onClick: () => fetchTournament(endMatch),
+            })
+          : null,
       ),
     ),
   )

--- a/static-builder/src/js/pages/Tournament.js
+++ b/static-builder/src/js/pages/Tournament.js
@@ -1,10 +1,10 @@
 import '@/scss/styles.scss'
-import { Teact } from '@/js/libs/teact'
-import { useNavigate, useLocation } from '@/js/libs/router'
-import { BaseLayout } from '@/js/layouts/BaseLayout'
 import { DefaultButton } from '@/js/components/ui/button'
 import { api } from '@/js/infrastructures/api/fetch'
 import { cookie } from '@/js/infrastructures/cookie/cookie'
+import { BaseLayout } from '@/js/layouts/BaseLayout'
+import { useLocation, useNavigate } from '@/js/libs/router'
+import { Teact } from '@/js/libs/teact'
 
 function sumVictoryCount(participants, start, end) {
   return participants


### PR DESCRIPTION
useEffect の cleanup 関数を使えるようにする

下の内容を`Home.js`とかにおくと確認できます
clickした後にreturnで返してるcleanup関数が実行されることが確認できればokです

```js
import { DefaultButton } from '@/js/components/ui/button'
import { BaseLayout } from '@/js/layouts/BaseLayout'
import { Teact } from '@/js/libs/teact'

export const Home = () => {
  const [clicked, setClicked] = Teact.useState(false)

  Teact.useEffect(() => {
    const id = setInterval(() => {
      console.log('Home page is mounted')
    }
    , 1000)

    return () => {
      clearInterval(id)
      console.log('Home page is unmounted')
    }
  }, [clicked])
  return BaseLayout(
    Teact.createElement(
      'div',
      { className: 'container vh-100' },
      Teact.createElement(
        'div',
        { className: 'd-grid gap-2 col-3 mx-auto' },
        DefaultButton({
          text: 'click',
          onClick: () =>
            setClicked(!clicked),
        }), // TBD
      ),
    ),
  )
}
```
<img width="1436" alt="Screenshot 2024-10-20 at 17 09 09" src="https://github.com/user-attachments/assets/85fe8dd8-a706-4246-86ae-47df08d83a2c">
