### PR TITLE
フロントエンドでビルドされた内容に環境変数が展開されなかった問題を修正する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: static-builder/
       target: build
       args:
-        VITE_API_URL: "ima kaita"
+        - VITE_API_URL
     container_name: "static-builder"
     volumes:
       - vol_static_builder:/usr/src/vite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     build:
       context: static-builder/
       target: build
+      args:
+        VITE_API_URL: "ima kaita"
     container_name: "static-builder"
     volumes:
       - vol_static_builder:/usr/src/vite

--- a/static-builder/Dockerfile
+++ b/static-builder/Dockerfile
@@ -18,6 +18,8 @@ COPY package.json pnpm-lock.yaml ./
 # build stage
 FROM base AS build
 
+ARG VITE_API_URL
+
 WORKDIR /usr/src/vite
 
 COPY ./ ./


### PR DESCRIPTION
`make build up`をした時に、フロントエンドコードに環境変数が展開されなかった問題を修正する

composeの`environement`セクションはコンテナ起動時に渡される環境変数で、イメージのビルド時には`args`で環境変数を渡す必要があるけど、それをしていなかったのが原因。
- ボリュームが残っていると前回ビルドした内容がマウントされて変更が確認できないので、`make fdown`を先に行う。
- `.env`の`VITE_API_URL`を変更して、コンテナ内で`grep -R {url} static-builder/dist` でその内容が展開されてるのを確認する。

ボリュームの問題は別のPRでやります。