### PR TITLE
Refs 168 friends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 .DS_Store
 reverseproxy/ssl/*
+note

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -46,6 +46,7 @@ RUN python manage.py startapp player
 RUN python manage.py startapp tournament
 RUN python manage.py startapp match
 RUN python manage.py startapp user
+RUN python manage.py startapp friend
 
 # project, appsのファイルをコピー
 COPY ./api/conf/project/* ${DJANGO_PROJECT_DIR}${DJANGO_PROJECT_NAME}/
@@ -53,6 +54,7 @@ COPY ./api/conf/app_player/* ${DJANGO_PROJECT_DIR}player/
 COPY ./api/conf/app_tournament/* ${DJANGO_PROJECT_DIR}tournament/
 COPY ./api/conf/app_match/* ${DJANGO_PROJECT_DIR}match/
 COPY ./api/conf/app_user/* ${DJANGO_PROJECT_DIR}user/
+COPY ./api/conf/app_friend/* ${DJANGO_PROJECT_DIR}friend/
 
 # Create utils Directory and Copy files
 RUN mkdir -p ${DJANGO_PROJECT_DIR}utils

--- a/api/conf/app_friend/models.py
+++ b/api/conf/app_friend/models.py
@@ -1,0 +1,18 @@
+from django.db import models
+from user.models import User
+
+class Friend(models.Model):
+    STATUS_CHOICES = (
+        ('pending', '申請中'),
+        ('accepted', '承認済み'),
+        ('rejected', '拒否'),
+    )
+    user = models.ForeignKey(User, related_name='friendships', on_delete=models.CASCADE)
+    friend = models.ForeignKey(User, related_name='friends_to', on_delete=models.CASCADE)
+    created_at = models.DateTimeField(auto_now_add=True)
+    status = models.CharField(max_length=10, choices=STATUS_CHOICES, default='pending')
+
+    class Meta:
+        db_table = 'friend'
+        unique_together = ('user', 'friend')
+

--- a/api/conf/app_friend/serializers.py
+++ b/api/conf/app_friend/serializers.py
@@ -1,0 +1,47 @@
+from rest_framework import serializers
+from .models import Friend
+
+# 出力用（友達リスト用）
+class FriendListSerializer(serializers.ModelSerializer):
+    id = serializers.SerializerMethodField()
+    friend_name = serializers.SerializerMethodField()
+    is_online = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Friend
+        fields = ['id', 'friend_name', 'is_online']
+
+    def get_id(self, obj):
+        return obj.friend.id
+
+    def get_friend_name(self, obj):
+        return obj.friend.display_name
+
+    def get_is_online(self, obj):
+        return obj.friend.last_online_at
+
+# 入力用（友達申請・作成用）
+class FriendCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Friend
+        fields = ['user', 'friend', 'status']
+
+# 申請リスト用
+class FriendRequestSerializer(serializers.ModelSerializer):
+    id = serializers.SerializerMethodField()
+    requester_name = serializers.SerializerMethodField()
+    requestee_name = serializers.SerializerMethodField()
+    requested_at = serializers.DateTimeField(source='created_at')
+
+    class Meta:
+        model = Friend
+        fields = ['id', 'requester_name', 'requestee_name', 'requested_at']
+
+    def get_id(self, obj):
+        return obj.user.id
+
+    def get_requester_name(self, obj):
+        return obj.user.display_name
+
+    def get_requestee_name(self, obj):
+        return obj.friend.display_name

--- a/api/conf/app_friend/views.py
+++ b/api/conf/app_friend/views.py
@@ -7,8 +7,8 @@ from .models import Friend
 from .serializers import FriendCreateSerializer, FriendListSerializer, FriendRequestSerializer
 from django.utils import timezone
 from datetime import timedelta
-
-# TODO 認証情報いったんだるいから外しているのであとで直す
+import traceback
+from user.utils import get_user_by_auth
 
 class FriendListByNameView(APIView):
 
@@ -23,42 +23,53 @@ class FriendListByNameView(APIView):
 class FriendRequestByNameView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
-    def post(self, request, display_name, friend_name):
-        if request.user.display_name != display_name:
-            return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
-        user = User.objects.filter(display_name=display_name).first()
-        friend = User.objects.filter(display_name=friend_name).first()
-        if not user or not friend:
-            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
-        if user == friend:
-            return Response({'error': 'You cannot add yourself as a friend'}, status=status.HTTP_400_BAD_REQUEST)
-        # 申請 or 承認（既に逆方向がpendingなら承認）
-        existing = Friend.objects.filter(user=friend, friend=user, status='pending').first()
-        if existing:
-            # 承認
-            existing.status = 'accepted'
-            existing.save()
-            Friend.objects.create(user=user, friend=friend, status='accepted')
-            return Response({'message': 'Friend request accepted'}, status=status.HTTP_200_OK)
-        # 新規申請
-        serializer = FriendCreateSerializer(data={'user': user.id, 'friend': friend.id, 'status': 'pending'})
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    def post(self, request, friend_name):
+        try:
+            access_id = get_user_by_auth(request.headers.get('Authorization'))
+            if not access_id:
+                raise AuthError('Authorization header is incorrect.')
 
-    def delete(self, request, display_name, friend_name):
-        if request.user.display_name != display_name:
-            return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
-        user = User.objects.filter(display_name=display_name).first()
+            user = User.objects.get(id=access_id)
+
+            friend = User.objects.filter(display_name=friend_name).first()
+            if not user or not friend or friend.deleted_at is not None:
+                return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+            if user == friend:
+                return Response({'error': 'You cannot add yourself as a friend'}, status=status.HTTP_400_BAD_REQUEST)
+            # 申請 or 承認（既に逆方向がpendingなら承認）
+            existing = Friend.objects.filter(user=friend, friend=user, status='pending').first()
+            if existing:
+                # 承認
+                existing.status = 'accepted'
+                existing.save()
+                Friend.objects.create(user=user, friend=friend, status='accepted')
+                return Response({'message': 'Friend request accepted'}, status=status.HTTP_200_OK)
+            # 新規申請
+            serializer = FriendCreateSerializer(data={'user': user.id, 'friend': friend.id, 'status': 'pending'})
+            if serializer.is_valid():
+                serializer.save()
+                return Response(serializer.data, status=status.HTTP_201_CREATED)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            with open('error.log', 'a') as f:
+                f.write(str(e))
+                traceback.print_exc(file=f)
+            return Response({'error': 'An unexpected error occurred'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    def delete(self, request, friend_name):
+        access_id = get_user_by_auth(request.headers.get('Authorization'))
+        if not access_id:
+            raise AuthError('Authorization header is incorrect.')
+
+        user = User.objects.get(id=access_id)
         friend = User.objects.filter(display_name=friend_name).first()
-        if not user or not friend:
+        if not user or not friend or friend.deleted_at is not None:
             return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
         if user == friend:
             return Response({'error': 'You cannot remove yourself as a friend'}, status=status.HTTP_400_BAD_REQUEST)
         # 申請拒否 or フレンド削除
-        deleted, _ = Friend.objects.filter(user=user, friend=friend).delete()
         Friend.objects.filter(user=friend, friend=user).delete()
+        Friend.objects.filter(user=user, friend=friend).delete()
         return Response({'message': 'Friend deleted'}, status=status.HTTP_200_OK)
 
 

--- a/api/conf/app_friend/views.py
+++ b/api/conf/app_friend/views.py
@@ -1,0 +1,75 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status, permissions
+from user.models import User
+from django.db.models import Q
+from .models import Friend
+from .serializers import FriendCreateSerializer, FriendListSerializer, FriendRequestSerializer
+from django.utils import timezone
+from datetime import timedelta
+
+# TODO 認証情報いったんだるいから外しているのであとで直す
+
+class FriendListByNameView(APIView):
+
+    def get(self, request, display_name):
+        user = User.objects.filter(display_name=display_name).first()
+        if not user:
+            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+        friends = Friend.objects.filter(user=user, status='accepted')
+        serializer = FriendListSerializer(friends, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+class FriendRequestByNameView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, display_name, friend_name):
+        # if request.user.display_name != display_name:
+        #     return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
+        user = User.objects.filter(display_name=display_name).first()
+        friend = User.objects.filter(display_name=friend_name).first()
+        if not user or not friend:
+            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+        if user == friend:
+            return Response({'error': 'You cannot add yourself as a friend'}, status=status.HTTP_400_BAD_REQUEST)
+        # 申請 or 承認（既に逆方向がpendingなら承認）
+        existing = Friend.objects.filter(user=friend, friend=user, status='pending').first()
+        if existing:
+            # 承認
+            existing.status = 'accepted'
+            existing.save()
+            Friend.objects.create(user=user, friend=friend, status='accepted')
+            return Response({'message': 'Friend request accepted'}, status=status.HTTP_200_OK)
+        # 新規申請
+        serializer = FriendCreateSerializer(data={'user': user.id, 'friend': friend.id, 'status': 'pending'})
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, display_name, friend_name):
+        # if request.user.display_name != display_name:
+        #     return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
+        user = User.objects.filter(display_name=display_name).first()
+        friend = User.objects.filter(display_name=friend_name).first()
+        if not user or not friend:
+            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+        if user == friend:
+            return Response({'error': 'You cannot remove yourself as a friend'}, status=status.HTTP_400_BAD_REQUEST)
+        # 申請拒否 or フレンド削除
+        deleted, _ = Friend.objects.filter(user=user, friend=friend).delete()
+        Friend.objects.filter(user=friend, friend=user).delete()
+        return Response({'message': 'Friend deleted'}, status=status.HTTP_200_OK)
+
+
+class FriendRequestsListByNameView(APIView):
+
+    def get(self, request, display_name):
+        if request.user.display_name != display_name:
+            return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
+        user = User.objects.filter(display_name=display_name).first()
+        if not user:
+            return Response({'error': 'User not found'}, status=status.HTTP_404_NOT_FOUND)
+        requests = Friend.objects.filter(Q(friend=user) | Q(user=user), status='pending')
+        serializer = FriendRequestSerializer(requests, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/api/conf/app_friend/views.py
+++ b/api/conf/app_friend/views.py
@@ -24,8 +24,8 @@ class FriendRequestByNameView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, display_name, friend_name):
-        # if request.user.display_name != display_name:
-        #     return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
+        if request.user.display_name != display_name:
+            return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
         user = User.objects.filter(display_name=display_name).first()
         friend = User.objects.filter(display_name=friend_name).first()
         if not user or not friend:
@@ -48,8 +48,8 @@ class FriendRequestByNameView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, display_name, friend_name):
-        # if request.user.display_name != display_name:
-        #     return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
+        if request.user.display_name != display_name:
+            return Response({'error': 'You are not authorized to access this resource.'}, status=status.HTTP_403_FORBIDDEN)
         user = User.objects.filter(display_name=display_name).first()
         friend = User.objects.filter(display_name=friend_name).first()
         if not user or not friend:
@@ -63,6 +63,7 @@ class FriendRequestByNameView(APIView):
 
 
 class FriendRequestsListByNameView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request, display_name):
         if request.user.display_name != display_name:

--- a/api/conf/app_user/auth_urls.py
+++ b/api/conf/app_user/auth_urls.py
@@ -3,6 +3,7 @@ from rest_framework.routers import DefaultRouter
 from .views import UserLoginView
 from .views import UserPasswordResetView
 from .views import UserSecretQuestionView
+from .views import UserCurrentView
 
 router = DefaultRouter()
 
@@ -10,4 +11,5 @@ urlpatterns = [
     path('login/', UserLoginView.as_view(), name='login'),
     path('password-reset/secret-question/', UserSecretQuestionView.as_view(), name='password_reset'),
     path('password-reset/', UserPasswordResetView.as_view(), name='secret_question'),
+    path('current-user/', UserCurrentView.as_view(), name='current_user'),
 ]

--- a/api/conf/app_user/models.py
+++ b/api/conf/app_user/models.py
@@ -20,9 +20,15 @@ class User(AbstractBaseUser):
     password = models.CharField(max_length=255)
     secret_question = models.CharField(max_length=255)
     secret_answer = models.CharField(max_length=255)
-    last_online_at = models.DateTimeField(default=None, null=True)
+    last_online_at = models.DateTimeField(default=timezone.now, null=True)
     deleted_at = models.DateTimeField(default=None, null=True)
     is_active = models.BooleanField(default=True)
+    friends = models.ManyToManyField(
+        'self',
+        through='friend.Friend',
+        symmetrical=False,
+        related_name='friend_of',
+    )
 
     objects = UserManager()
 

--- a/api/conf/app_user/user_urls.py
+++ b/api/conf/app_user/user_urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     path('', UserView.as_view(), name='user'),
     path('<str:display_name>/friends', FriendListByNameView.as_view()),
     path('<str:display_name>/friend_requests', FriendRequestsListByNameView.as_view()),
-    path('<str:display_name>/friends/<str:friend_name>', FriendRequestByNameView.as_view()),
+    path('friends/<str:friend_name>', FriendRequestByNameView.as_view()),
     path('last_login/', UpdateLastLoginView.as_view(), name='update_last_login'),
     path('update/', UserUpdateView.as_view(), name='user_update'),
     path('user/<str:display_name>/', UserProfileView.as_view(), name='profile'),

--- a/api/conf/app_user/user_urls.py
+++ b/api/conf/app_user/user_urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 from .views import UserView
+from friend.views import (
+    FriendListByNameView,
+    FriendRequestByNameView,
+    FriendRequestsListByNameView,
+)
 from .views import UpdateLastLoginView
 from .views import UserUpdateView
 from .views import UserProfileView
@@ -8,6 +13,9 @@ router = DefaultRouter()
 
 urlpatterns = [
     path('', UserView.as_view(), name='user'),
+    path('<str:display_name>/friends', FriendListByNameView.as_view()),
+    path('<str:display_name>/friend_requests', FriendRequestsListByNameView.as_view()),
+    path('<str:display_name>/friends/<str:friend_name>', FriendRequestByNameView.as_view()),
     path('last_login/', UpdateLastLoginView.as_view(), name='update_last_login'),
     path('update/', UserUpdateView.as_view(), name='user_update'),
     path('user/<str:display_name>/', UserProfileView.as_view(), name='profile'),

--- a/api/conf/app_user/utils.py
+++ b/api/conf/app_user/utils.py
@@ -1,4 +1,5 @@
 from .models import User
+from friend.models import Friend
 from django.db.models import Q
 from match.models import Match, MatchDetail
 from rest_framework_simplejwt.tokens import AccessToken
@@ -29,7 +30,7 @@ def create_response(user, access_id):
   response = {
       'display_name': user.display_name,
       'avatar_path': user.avatar_path,
-      'num_of_friends': '3',
+      'num_of_friends': Friend.objects.filter(user_id=user.id, status='accepted').count(),
       'performance': {
           'game_records': game_records,
           'statistics': {

--- a/api/conf/app_user/utils.py
+++ b/api/conf/app_user/utils.py
@@ -16,12 +16,12 @@ def get_opponent_user_and_score(match_id, user_id):
 def get_relation_to_current_user(user_id, access_id):
   if user_id == access_id:
     return 'self'
-  if Friend.objects.filter(user_id=user_id, status='accepted').exists():
+  if Friend.objects.filter(user_id=user_id, friend_id=access_id, status='accepted').exists():
     return 'friend'
-  if Friend.objects.filter(user_id=user_id, status='pending').exists():
-    return 'request_received'
-  if Friend.objects.filter( friend_id=user_id, status='pending').exists():
+  if Friend.objects.filter(user_id=access_id, friend_id=user_id, status='pending').exists():
     return 'requesting'
+  if Friend.objects.filter(user_id=user_id, friend_id=access_id, status='pending').exists():
+    return 'request_received'
   return 'stranger'
 
 def create_response(user, access_id):

--- a/api/conf/app_user/utils.py
+++ b/api/conf/app_user/utils.py
@@ -13,6 +13,17 @@ def get_opponent_user_and_score(match_id, user_id):
       return User.objects.get(id=match_detail.player_id.id), match_detail.score
   return None
 
+def get_relation_to_current_user(user_id, access_id):
+  if user_id == access_id:
+    return 'self'
+  if Friend.objects.filter(user_id=user_id, status='accepted').exists():
+    return 'friend'
+  if Friend.objects.filter(user_id=user_id, status='pending').exists():
+    return 'request_received'
+  if Friend.objects.filter( friend_id=user_id, status='pending').exists():
+    return 'requesting'
+  return 'stranger'
+
 def create_response(user, access_id):
   match_details = MatchDetail.objects.filter(player_id_id=user.id)
   game_records = []
@@ -31,6 +42,7 @@ def create_response(user, access_id):
       'display_name': user.display_name,
       'avatar_path': user.avatar_path,
       'num_of_friends': Friend.objects.filter(user_id=user.id, status='accepted').count(),
+      'relation_to_current_user': get_relation_to_current_user(user.id, access_id),
       'performance': {
           'game_records': game_records,
           'statistics': {

--- a/api/conf/app_user/views.py
+++ b/api/conf/app_user/views.py
@@ -277,3 +277,35 @@ class UserUpdateView(APIView):
                     'message': str(e)
                 }]
             }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class UserCurrentView(APIView):
+    def get(self, request):
+        try:
+            access_id = get_user_by_auth(request.headers.get('Authorization'))
+            if not access_id:
+                raise AuthError('Authorization header is incorrect.')
+            user = User.objects.get(id=access_id)
+            data = create_response(user, access_id)
+            return JsonResponse(data)
+        except AuthError as auth_error:
+            return JsonResponse({
+                'errors': [{
+                    'field': 'auth',
+                    'message': str(auth_error)
+                }]
+            }, status=auth_error.status_code)
+        except User.DoesNotExist:
+            return JsonResponse({
+                'errors': [{
+                    'field': 'user',
+                    'message': 'User not found.'
+                }]
+            }, status=status.HTTP_404_NOT_FOUND)
+        except Exception as e:
+            return JsonResponse({
+                'errors': [{
+                    'field': 'unknown',
+                    'message': str(e)
+                }]
+            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/api/conf/project/settings.py
+++ b/api/conf/project/settings.py
@@ -70,6 +70,7 @@ INSTALLED_APPS = [
     'tournament',
     'match',
     'user',
+    'friend',
 
     # 3rd party
     'rest_framework',

--- a/api/dev/settings.py
+++ b/api/dev/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'tournament',
     'match',
     'user',
+    'friend',
 
     # 3rd party apps
     'rest_framework',

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -134,6 +134,26 @@ paths:
               schema:
                 $ref: "#/components/schemas/error_response"
 
+  /api/auth/current-user:
+    post:
+      tags:
+        - user_management
+      summary: ログインユーザーの情報取得
+      description: ログイン中のユーザーがあればその情報を取得します。
+      responses:
+        "200":
+          description: ログイン成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/user_response"
+        default:
+          description: エラーレスポンスまたはその他のレスポンス
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_response"
+
   /api/auth/password-reset:
     post:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -206,9 +206,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error_response"
 
-  /api/users/{display_name}/friends/{friend_name}:
+  /api/users/friends/{friend_name}:
     parameters:
-      - $ref: "#/components/parameters/display_name"
       - $ref: "#/components/parameters/friend_name"
     post:
       tags:

--- a/static-builder/src/js/components/common/Header.js
+++ b/static-builder/src/js/components/common/Header.js
@@ -92,7 +92,6 @@ export const Header = () => {
         return response.json()
       })
       .then(data => {
-        console.log(data)
         setUser(data)
       })
       .catch(error => {

--- a/static-builder/src/js/components/common/Header.js
+++ b/static-builder/src/js/components/common/Header.js
@@ -53,7 +53,7 @@ const renderAvatarSection = avatar_path => {
         Teact.createElement('img', {
           src: `${avatar_path}?${new Date().getTime()}`,
           className: 'img-fluid profile-icon',
-          alt: 'Avator',
+          alt: 'Avatar',
           width: '10',
           height: '10',
         }),

--- a/static-builder/src/js/components/common/Header.js
+++ b/static-builder/src/js/components/common/Header.js
@@ -1,6 +1,8 @@
 import { Link } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 import Icon from '/icon.png'
+import { userApi } from '@/js/infrastructures/api/userApi'
+import { useNavigate } from '@/js/libs/router'
 
 const handleLogout = () => {
   if (localStorage.getItem('access_token')) {
@@ -38,6 +40,28 @@ const displayAuth = () => {
   )
 }
 
+const renderAvatarSection = avatar_path => {
+  return Teact.createElement(
+    'div',
+    { className: 'text-center' },
+    Teact.createElement(
+      'div',
+      { className: '' },
+      Teact.createElement(
+        'label',
+        null,
+        Teact.createElement('img', {
+          src: `${avatar_path}?${new Date().getTime()}`,
+          className: 'img-fluid profile-icon',
+          alt: 'Avator',
+          width: '10',
+          height: '10',
+        }),
+      ),
+    ),
+  )
+}
+
 const displayRegister = () => {
   if (localStorage.getItem('access_token')) {
     return null
@@ -54,6 +78,27 @@ const displayRegister = () => {
 }
 
 export const Header = () => {
+  const [user, setUser] = Teact.useState(null)
+  const navigate = useNavigate()
+  Teact.useEffect(() => {
+    userApi
+      .getCurrentUser()
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(errData => {
+            throw new Error(errData.error || 'Unknown error occurred')
+          })
+        }
+        return response.json()
+      })
+      .then(data => {
+        console.log(data)
+        setUser(data)
+      })
+      .catch(error => {
+        return null
+      })
+  }, [])
   return Teact.createElement(
     'header',
     { className: 'bg-darkblue text-white p-3 border-bottom border-warning' },
@@ -63,15 +108,20 @@ export const Header = () => {
         className:
           'container-fluid d-flex justify-content-between align-items-center',
       },
+
       Teact.createElement(
-        'a',
-        { href: '/', className: 'text-white' },
-        Teact.createElement('img', {
-          src: Icon,
-          alt: 'Logo',
-          width: '30',
-          height: '30',
-        }),
+        'div',
+        { className: 'd-flex align-items-center' },
+        Teact.createElement(
+          'a',
+          { href: '/', className: 'text-white' },
+          Teact.createElement('img', {
+            src: Icon,
+            alt: 'Logo',
+            width: '30',
+            height: '30',
+          }),
+        ),
       ),
       Teact.createElement(
         'nav',
@@ -80,22 +130,30 @@ export const Header = () => {
           'ul',
           { className: 'nav' },
           Teact.createElement(
-            'li',
-            { className: 'nav-item' },
-            Link({
-              to: '/about',
-              className: 'nav-link text-white no-pointer-events',
-              children: ['About'],
-            }),
-          ),
-          Teact.createElement(
-            'li',
-            { className: 'nav-item' },
-            Link({
-              to: '/services',
-              className: 'nav-link text-white no-pointer-events',
-              children: ['Services'],
-            }),
+            'div',
+            { className: 'd-flex align-items-center' },
+            renderAvatarSection(user?.avatar_path),
+            user
+              ? Teact.createElement(
+                  'li',
+                  {
+                    className: 'nav-link text-info ms-1',
+                  },
+                  Teact.createElement(
+                    'span',
+                    { className: 'nav-item d-flex' },
+                    Link({
+                      to: `/users/${user.display_name}`,
+                      className: 'nav-link text-white p-0 ms-3',
+                      children: [user.display_name],
+                    }),
+                  ),
+                )
+              : Teact.createElement(
+                  'span',
+                  { className: 'nav-link text-white no-pointer-events ms-3' },
+                  'Hello, guest',
+                ),
           ),
           Teact.createElement(
             'li',

--- a/static-builder/src/js/features/friends/FriendsTable.js
+++ b/static-builder/src/js/features/friends/FriendsTable.js
@@ -116,11 +116,16 @@ export const FriendsTable = ({
     )
   }
   // 最大の長さを見つける
-  const maxLength = Math.max(friends.length, friendRequests.length)
+  const maxLength = Math.max(
+    Array.isArray(friends) ? friends.length : 0,
+    Array.isArray(friendRequests) ? friendRequests.length : 0,
+  )
 
   // 必要な数だけ空の要素で埋める配列を作成
-  const paddedFriends = [...friends]
-  const paddedRequests = [...friendRequests]
+  const paddedFriends = Array.isArray(friends) ? [...friends] : []
+  const paddedRequests = Array.isArray(friendRequests)
+    ? [...friendRequests]
+    : []
 
   // 足りない分を空の要素（null や空のオブジェクト）で埋める
   while (paddedFriends.length < maxLength) {
@@ -139,6 +144,20 @@ export const FriendsTable = ({
     })
   }
 
+  const friendRequestsTab = () => {
+    if (friendRequests === undefined) {
+      return null
+    }
+    return Teact.createElement(
+      'button',
+      {
+        className: `nav-link ${activeTab === 'requests' ? 'active' : ''}`,
+        onClick: () => setActiveTab('requests'),
+      },
+      'フレンド申請',
+    )
+  }
+
   return Teact.createElement(
     'div',
     { className: 'container mt-4' },
@@ -153,14 +172,7 @@ export const FriendsTable = ({
         },
         'フレンド一覧',
       ),
-      Teact.createElement(
-        'button',
-        {
-          className: `nav-link ${activeTab === 'requests' ? 'active' : ''}`,
-          onClick: () => setActiveTab('requests'),
-        },
-        'フレンド申請',
-      ),
+      friendRequestsTab(),
     ),
 
     Teact.createElement(

--- a/static-builder/src/js/features/friends/FriendsTable.js
+++ b/static-builder/src/js/features/friends/FriendsTable.js
@@ -15,7 +15,7 @@ export const FriendsTable = ({
       {
         className: `badge ${isOnline ? 'bg-success' : 'bg-secondary'} rounded-pill`,
       },
-      isOnline ? 'オンライン' : 'オフライン',
+      isOnline ? 'Online' : 'Offline',
     )
   }
 
@@ -30,12 +30,12 @@ export const FriendsTable = ({
       Teact.createElement(
         'tr',
         null,
-        Teact.createElement('th', null, '名前'),
+        Teact.createElement('th', null, 'Name'),
         activeTab === 'requests'
-          ? Teact.createElement('th', null, '申請日時')
-          : Teact.createElement('th', null, 'ステータス'),
+          ? Teact.createElement('th', null, 'Requested At')
+          : Teact.createElement('th', null, 'Status'),
         activeTab === 'requests'
-          ? Teact.createElement('th', null, 'アクション')
+          ? Teact.createElement('th', null, 'Action')
           : Teact.createElement('th', null, ''),
       ),
     )
@@ -63,7 +63,7 @@ export const FriendsTable = ({
           {
             className: 'badge bg-dark-subtle rounded-pill',
           },
-          'フレンド申請中',
+          'Waiting for Response',
         ),
       )
     }
@@ -76,7 +76,7 @@ export const FriendsTable = ({
           className: 'btn btn-success btn-sm me-2',
           onClick: () => onAccept(friend.requester_name),
         },
-        '承認',
+        'Accept',
       ),
       Teact.createElement(
         'button',
@@ -84,7 +84,7 @@ export const FriendsTable = ({
           className: 'btn btn-danger btn-sm',
           onClick: () => onReject(friend.requester_name),
         },
-        '拒否',
+        'Reject',
       ),
     )
   }
@@ -154,7 +154,7 @@ export const FriendsTable = ({
         className: `nav-link ${activeTab === 'requests' ? 'active' : ''}`,
         onClick: () => setActiveTab('requests'),
       },
-      'フレンド申請',
+      'Friend Request',
     )
   }
 
@@ -170,7 +170,7 @@ export const FriendsTable = ({
           className: `nav-link ${activeTab === 'list' ? 'active' : ''}`,
           onClick: () => setActiveTab('list'),
         },
-        'フレンド一覧',
+        'Friends List',
       ),
       friendRequestsTab(),
     ),

--- a/static-builder/src/js/features/friends/FriendsTable.js
+++ b/static-builder/src/js/features/friends/FriendsTable.js
@@ -74,7 +74,7 @@ export const FriendsTable = ({
         'button',
         {
           className: 'btn btn-success btn-sm me-2',
-          onClick: () => onAccept(friend.id),
+          onClick: () => onAccept(friend.requester_name),
         },
         '承認',
       ),
@@ -82,7 +82,7 @@ export const FriendsTable = ({
         'button',
         {
           className: 'btn btn-danger btn-sm',
-          onClick: () => onReject(friend.id),
+          onClick: () => onReject(friend.requester_name),
         },
         '拒否',
       ),

--- a/static-builder/src/js/features/friends/FriendsTable.js
+++ b/static-builder/src/js/features/friends/FriendsTable.js
@@ -41,13 +41,25 @@ export const FriendsTable = ({
     )
   }
   const name = friend => {
-    if (activeTab === 'list') {
-      return friend.friend_name
+    const displayName =
+      activeTab === 'list'
+        ? friend.friend_name
+        : friend.requester_name === userName
+          ? friend.requestee_name
+          : friend.requester_name
+
+    if (!displayName) {
+      return ''
     }
-    if (friend.requester_name === userName) {
-      return friend.requestee_name
-    }
-    return friend.requester_name
+
+    return Teact.createElement(
+      'a',
+      {
+        href: `/users/${displayName}`,
+        className: 'text-decoration-none',
+      },
+      displayName,
+    )
   }
 
   const requestAction = friend => {

--- a/static-builder/src/js/features/friends/FriendsTable.js
+++ b/static-builder/src/js/features/friends/FriendsTable.js
@@ -1,6 +1,12 @@
 import { Teact } from '@/js/libs/teact'
 
-export const FriendsTable = ({ friends, onAccept, onReject }) => {
+export const FriendsTable = ({
+  friends,
+  userName,
+  friendRequests,
+  onAccept,
+  onReject,
+}) => {
   const [activeTab, setActiveTab] = Teact.useState('list') // 'list' or 'requests'
 
   const renderStatus = isOnline => {
@@ -13,6 +19,10 @@ export const FriendsTable = ({ friends, onAccept, onReject }) => {
     )
   }
 
+  const renderDate = date => {
+    return Teact.createElement('span', null, new Date(date).toLocaleString())
+  }
+
   const renderTableHeader = () => {
     return Teact.createElement(
       'thead',
@@ -21,43 +31,112 @@ export const FriendsTable = ({ friends, onAccept, onReject }) => {
         'tr',
         null,
         Teact.createElement('th', null, '名前'),
-        Teact.createElement('th', null, 'ステータス'),
+        activeTab === 'requests'
+          ? Teact.createElement('th', null, '申請日時')
+          : Teact.createElement('th', null, 'ステータス'),
         activeTab === 'requests'
           ? Teact.createElement('th', null, 'アクション')
           : Teact.createElement('th', null, ''),
       ),
     )
   }
+  const name = friend => {
+    if (activeTab === 'list') {
+      return friend.friend_name
+    }
+    if (friend.requester_name === userName) {
+      return friend.requestee_name
+    }
+    return friend.requester_name
+  }
+
+  const requestAction = friend => {
+    if (activeTab === 'list') {
+      return Teact.createElement('td', null, '')
+    }
+    if (friend.requester_name === userName) {
+      return Teact.createElement(
+        'td',
+        null,
+        Teact.createElement(
+          'span',
+          {
+            className: 'badge bg-dark-subtle rounded-pill',
+          },
+          'フレンド申請中',
+        ),
+      )
+    }
+    return Teact.createElement(
+      'td',
+      { className: 'action-buttons' },
+      Teact.createElement(
+        'button',
+        {
+          className: 'btn btn-success btn-sm me-2',
+          onClick: () => onAccept(friend.id),
+        },
+        '承認',
+      ),
+      Teact.createElement(
+        'button',
+        {
+          className: 'btn btn-danger btn-sm',
+          onClick: () => onReject(friend.id),
+        },
+        '拒否',
+      ),
+    )
+  }
 
   const renderTableRow = friend => {
+    const isEmpty =
+      friend.id &&
+      typeof friend.id === 'string' &&
+      friend.id.startsWith('empty-')
+
+    if (isEmpty) {
+      // 空の行の場合
+      return Teact.createElement(
+        'tr',
+        { key: friend.id, className: 'empty-row' },
+        Teact.createElement('td', null, ''),
+        Teact.createElement('td', null, ''),
+        Teact.createElement('td', null, ''),
+      )
+    }
     return Teact.createElement(
       'tr',
       { key: friend.id },
-      Teact.createElement('td', null, friend.friend_name),
-      Teact.createElement('td', null, renderStatus(friend.is_online)),
+      Teact.createElement('td', null, name(friend)),
       activeTab === 'requests'
-        ? Teact.createElement(
-            'td',
-            { className: 'action-buttons' },
-            Teact.createElement(
-              'button',
-              {
-                className: 'btn btn-success btn-sm me-2',
-                onClick: () => onAccept(friend.id),
-              },
-              '承認',
-            ),
-            Teact.createElement(
-              'button',
-              {
-                className: 'btn btn-danger btn-sm',
-                onClick: () => onReject(friend.id),
-              },
-              '拒否',
-            ),
-          )
-        : Teact.createElement('td', null, ''),
+        ? Teact.createElement('td', null, renderDate(friend.requested_at))
+        : Teact.createElement('td', null, renderStatus(friend.is_online)),
+      requestAction(friend),
     )
+  }
+  // 最大の長さを見つける
+  const maxLength = Math.max(friends.length, friendRequests.length)
+
+  // 必要な数だけ空の要素で埋める配列を作成
+  const paddedFriends = [...friends]
+  const paddedRequests = [...friendRequests]
+
+  // 足りない分を空の要素（null や空のオブジェクト）で埋める
+  while (paddedFriends.length < maxLength) {
+    paddedFriends.push({
+      id: `empty-${paddedFriends.length}`,
+      friend_name: '',
+      is_online: false,
+    })
+  }
+
+  while (paddedRequests.length < maxLength) {
+    paddedRequests.push({
+      id: `empty-${paddedRequests.length}`,
+      friend_name: '',
+      is_online: false,
+    })
   }
 
   return Teact.createElement(
@@ -83,11 +162,22 @@ export const FriendsTable = ({ friends, onAccept, onReject }) => {
         'フレンド申請',
       ),
     ),
+
     Teact.createElement(
       'table',
       { className: 'table table-hover friend-table' },
       renderTableHeader(),
-      Teact.createElement('tbody', null, ...friends.map(renderTableRow)),
+      activeTab === 'list'
+        ? Teact.createElement(
+            'tbody',
+            null,
+            ...paddedFriends.map(renderTableRow),
+          )
+        : Teact.createElement(
+            'tbody',
+            null,
+            ...paddedRequests.map(renderTableRow),
+          ),
     ),
   )
 }

--- a/static-builder/src/js/infrastructures/api/userApi.js
+++ b/static-builder/src/js/infrastructures/api/userApi.js
@@ -62,14 +62,14 @@ function changeProfile(data) {
 }
 
 function getFriendsList(data) {
-  return api.get('/api/users/${data.display_name}/friends').then(response => {
+  return api.get(`/api/users/${data.display_name}/friends`).then(response => {
     return response
   })
 }
 
 function getFriendRequests(data) {
   return api
-    .get('/api/users/${data.display_name}/friend_requests')
+    .get(`/api/users/${data.display_name}/friend_requests`)
     .then(response => {
       return response
     })
@@ -77,7 +77,7 @@ function getFriendRequests(data) {
 
 function friendRequest(data) {
   return api
-    .post('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .post(`/api/users/${data.user_name}/friends/${data.friend_name}`)
     .then(response => {
       return response
     })
@@ -85,7 +85,7 @@ function friendRequest(data) {
 
 function acceptFriendRequest(data) {
   return api
-    .post('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .post(`/api/users/${data.user_name}/friends/${data.friend_name}`)
     .then(response => {
       return response
     })
@@ -93,7 +93,7 @@ function acceptFriendRequest(data) {
 
 function rejectFriendRequest(data) {
   return api
-    .delete('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .delete(`/api/users/${data.user_name}/friends/${data.friend_name}`)
     .then(response => {
       return response
     })
@@ -101,7 +101,7 @@ function rejectFriendRequest(data) {
 
 function deleteFriend(data) {
   return api
-    .delete('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .delete(`/api/users/${data.user_name}/friends/${data.friend_name}`)
     .then(response => {
       return response
     })

--- a/static-builder/src/js/infrastructures/api/userApi.js
+++ b/static-builder/src/js/infrastructures/api/userApi.js
@@ -107,7 +107,6 @@ function deleteFriend(data) {
     })
 }
 
-
 export const userApi = {
   login,
   register,

--- a/static-builder/src/js/infrastructures/api/userApi.js
+++ b/static-builder/src/js/infrastructures/api/userApi.js
@@ -76,35 +76,27 @@ function getFriendRequests(data) {
 }
 
 function friendRequest(data) {
-  return api
-    .post(`/api/users/${data.user_name}/friends/${data.friend_name}`)
-    .then(response => {
-      return response
-    })
+  return api.post(`/api/users/friends/${data.friend_name}`).then(response => {
+    return response
+  })
 }
 
 function acceptFriendRequest(data) {
-  return api
-    .post(`/api/users/${data.user_name}/friends/${data.friend_name}`)
-    .then(response => {
-      return response
-    })
+  return api.post(`/api/users/friends/${data.friend_name}`).then(response => {
+    return response
+  })
 }
 
 function rejectFriendRequest(data) {
-  return api
-    .delete(`/api/users/${data.user_name}/friends/${data.friend_name}`)
-    .then(response => {
-      return response
-    })
+  return api.delete(`/api/users/friends/${data.friend_name}`).then(response => {
+    return response
+  })
 }
 
 function deleteFriend(data) {
-  return api
-    .delete(`/api/users/${data.user_name}/friends/${data.friend_name}`)
-    .then(response => {
-      return response
-    })
+  return api.delete(`/api/users/friends/${data.friend_name}`).then(response => {
+    return response
+  })
 }
 
 export const userApi = {

--- a/static-builder/src/js/infrastructures/api/userApi.js
+++ b/static-builder/src/js/infrastructures/api/userApi.js
@@ -99,12 +99,19 @@ function deleteFriend(data) {
   })
 }
 
+function getCurrentUser() {
+  return api.get('/api/auth/current-user/').then(response => {
+    return response
+  })
+}
+
 export const userApi = {
   login,
   register,
   passwordReset,
   getSecretQuestion,
   deleteAccount,
+  getCurrentUser,
 
   getProfile,
   changeProfile,

--- a/static-builder/src/js/infrastructures/api/userApi.js
+++ b/static-builder/src/js/infrastructures/api/userApi.js
@@ -61,12 +61,68 @@ function changeProfile(data) {
   })
 }
 
+function getFriendsList(data) {
+  return api.get('/api/users/${data.display_name}/friends').then(response => {
+    return response
+  })
+}
+
+function getFriendRequests(data) {
+  return api
+    .get('/api/users/${data.display_name}/friend_requests')
+    .then(response => {
+      return response
+    })
+}
+
+function friendRequest(data) {
+  return api
+    .post('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .then(response => {
+      return response
+    })
+}
+
+function acceptFriendRequest(data) {
+  return api
+    .post('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .then(response => {
+      return response
+    })
+}
+
+function rejectFriendRequest(data) {
+  return api
+    .delete('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .then(response => {
+      return response
+    })
+}
+
+function deleteFriend(data) {
+  return api
+    .delete('/api/users/${data.user_name}/friends/${data.friend_name}')
+    .then(response => {
+      return response
+    })
+}
+
+
 export const userApi = {
   login,
   register,
   passwordReset,
   getSecretQuestion,
   deleteAccount,
+
   getProfile,
   changeProfile,
+
+  getFriendsList,
+  getFriendRequests,
+
+  friendRequest,
+  acceptFriendRequest,
+  rejectFriendRequest,
+  deleteFriend,
 }

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -9,13 +9,22 @@ const mockFriends = [
   { id: 3, friend_name: 'baz', is_online: true },
 ]
 
-export const FriendsList = () => {
+const mockFriendRequests = [
+  { id: 1, requester_name: 'a', requestee_name: 'b', requested_at: new Date() },
+  { id: 2, requester_name: 'a', requestee_name: 'c', requested_at: new Date() },
+  { id: 3, requester_name: 'a', requestee_name: 'd', requested_at: new Date() },
+  { id: 4, requester_name: 'e', requestee_name: 'a', requested_at: new Date() },
+]
+
+export const FriendsList = props => {
   return SimpleHeaderLayout(
     Teact.createElement(
       'div',
       { className: 'container bg-white p-4 rounded shadow' },
       Teact.createElement(FriendsTable, {
         friends: mockFriends,
+        userName: props.params.id,
+        friendRequests: mockFriendRequests,
         onAccept: () => {},
         onReject: () => {},
       }),

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -17,7 +17,6 @@ export const FriendsList = props => {
     // 友達リストの取得
     friends(props.params.id).then(data => {
       setFriendsList(data)
-      setLoading(false)
     })
 
     // 友達リクエストの取得
@@ -71,7 +70,6 @@ export const FriendsList = props => {
   const handleAccept = friendId => {
     userApi
       .acceptFriendRequest({
-        user_name: props.params.id,
         friend_name: friendId,
       })
       .then(() => {
@@ -87,7 +85,6 @@ export const FriendsList = props => {
   const handleReject = friendId => {
     userApi
       .deleteFriend({
-        user_name: props.params.id,
         friend_name: friendId,
       })
       .then(() => {

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -17,6 +17,7 @@ export const FriendsList = props => {
     // 友達リストの取得
     friends(props.params.id).then(data => {
       setFriendsList(data)
+      setLoading(false)
     })
 
     // 友達リクエストの取得

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -1,32 +1,109 @@
 import { FriendsTable } from '@/js/features/friends/FriendsTable'
 import { SimpleHeaderLayout } from '@/js/layouts/SimpleHeaderLayout'
 import { Teact } from '@/js/libs/teact'
-
-// モックデータ
-const mockFriends = [
-  { id: 1, friend_name: 'foo', is_online: true },
-  { id: 2, friend_name: 'bar', is_online: false },
-  { id: 3, friend_name: 'baz', is_online: true },
-]
-
-const mockFriendRequests = [
-  { id: 1, requester_name: 'a', requestee_name: 'b', requested_at: new Date() },
-  { id: 2, requester_name: 'a', requestee_name: 'c', requested_at: new Date() },
-  { id: 3, requester_name: 'a', requestee_name: 'd', requested_at: new Date() },
-  { id: 4, requester_name: 'e', requestee_name: 'a', requested_at: new Date() },
-]
+import { userApi } from '@/js/infrastructures/api/userApi'
 
 export const FriendsList = props => {
+  // ステートを定義
+  const [friendsList, setFriendsList] = Teact.useState([])
+  const [friendRequests, setFriendRequests] = Teact.useState([])
+  const [loading, setLoading] = Teact.useState(true)
+
+  // コンポーネントがマウントされたときにデータを取得
+  Teact.useEffect(() => {
+    // 友達リストの取得
+    friends(props.params.id).then(data => {
+      setFriendsList(data)
+      setLoading(false)
+    })
+
+    // 友達リクエストの取得
+    requests(props.params.id).then(data => {
+      setFriendRequests(data)
+    })
+  }, [props.params.id]) // propsのidが変わったら再度実行
+
+  // APIデータ取得関数
+  const friends = id =>
+    userApi
+      .getFriendsList({ display_name: id })
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(errData => {
+            throw new Error(errData.error || 'Unknown error occurred')
+          })
+        }
+        return response.json()
+      })
+      .catch(error => {
+        console.error(error)
+        return []
+      })
+
+  const requests = id =>
+    userApi
+      .getFriendRequests({ display_name: id })
+      .then(response => {
+        if (!response.ok) {
+          return response.json().then(errData => {
+            throw new Error(errData.error || 'Unknown error occurred')
+          })
+        }
+        return response.json()
+      })
+      .catch(error => {
+        console.error(error)
+        return []
+      })
+
+  // ハンドラー関数をコンポーネント内に移動
+  const handleAccept = friendId => {
+    userApi
+      .acceptFriendRequest({
+        user_name: props.params.id,
+        friend_name: friendId,
+      })
+      .then(response => {
+        console.log(response)
+        // 友達リクエストリストを更新
+        setFriendRequests(prev => prev.filter(req => req.id !== friendId))
+      })
+  }
+
+  const handleReject = friendId => {
+    userApi
+      .deleteFriend({
+        user_name: props.params.id,
+        friend_name: friendId,
+      })
+      .then(response => {
+        console.log(response)
+        // 友達リクエストリストを更新
+        setFriendRequests(prev => prev.filter(req => req.id !== friendId))
+      })
+  }
+
+  // ローディング中の表示
+  if (loading) {
+    return SimpleHeaderLayout(
+      Teact.createElement(
+        'div',
+        { className: 'container bg-white p-4 rounded shadow text-center' },
+        'データを読み込み中...',
+      ),
+    )
+  }
+
   return SimpleHeaderLayout(
     Teact.createElement(
       'div',
       { className: 'container bg-white p-4 rounded shadow' },
       Teact.createElement(FriendsTable, {
-        friends: mockFriends,
+        friends: friendsList, // ステートから値を渡す
         userName: props.params.id,
-        friendRequests: mockFriendRequests,
-        onAccept: () => {},
-        onReject: () => {},
+        friendRequests: friendRequests, // ステートから値を渡す
+        onAccept: handleAccept,
+        onReject: handleReject,
       }),
     ),
   )

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -23,8 +23,9 @@ export const FriendsList = props => {
     // 友達リクエストの取得
     requests(props.params.id).then(data => {
       setFriendRequests(data)
+      setLoading(false)
     })
-  }, [props.params.id]) // propsのidが変わったら再度実行
+  }, [props.params.id, loading]) // propsのidが変わったら再度実行
 
   // APIデータ取得関数
   const friends = id =>
@@ -50,9 +51,12 @@ export const FriendsList = props => {
       .getFriendRequests({ display_name: id })
       .then(response => {
         if (!response.ok) {
-          return response.json().then(errData => {
-            throw new Error(errData.error || 'Unknown error occurred')
-          })
+          if (response.status !== 403) {
+            return response.json().then(errData => {
+              throw new Error(errData.error || 'Unknown error occurred')
+            })
+          }
+          return undefined
         }
         return response.json()
       })
@@ -76,6 +80,8 @@ export const FriendsList = props => {
       .then(data => {
         navigate(`users/${id}/friends`)
       })
+
+    setLoading(true)
   }
 
   const handleReject = friendId => {
@@ -90,6 +96,8 @@ export const FriendsList = props => {
       .then(data => {
         navigate(`users/${id}/friends`)
       })
+
+    setLoading(true)
   }
 
   // ローディング中の表示
@@ -116,17 +124,21 @@ export const FriendsList = props => {
   }
 
   return SimpleHeaderLayout(
-    ...banners,
     Teact.createElement(
       'div',
-      { className: 'container bg-white p-4 rounded shadow' },
-      Teact.createElement(FriendsTable, {
-        friends: friendsList,
-        userName: props.params.id,
-        friendRequests: friendRequests,
-        onAccept: handleAccept,
-        onReject: handleReject,
-      }),
+      { className: 'container' },
+      ...banners,
+      Teact.createElement(
+        'div',
+        { className: 'container bg-white p-4 rounded shadow' },
+        Teact.createElement(FriendsTable, {
+          friends: friendsList,
+          userName: props.params.id,
+          friendRequests: friendRequests,
+          onAccept: handleAccept,
+          onReject: handleReject,
+        }),
+      ),
     ),
   )
 }

--- a/static-builder/src/js/pages/FriendsList.js
+++ b/static-builder/src/js/pages/FriendsList.js
@@ -21,7 +21,7 @@ export const FriendsList = props => {
     requests(props.params.id).then(data => {
       setFriendRequests(data)
     })
-  }, [props.params.id]) // propsのidが変わったら再度実行
+  }, [props.params.id, setFriendsList, setFriendRequests]) // propsのidが変わったら再度実行
 
   // APIデータ取得関数
   const friends = id =>
@@ -63,9 +63,7 @@ export const FriendsList = props => {
         user_name: props.params.id,
         friend_name: friendId,
       })
-      .then(response => {
-        console.log(response)
-        // 友達リクエストリストを更新
+      .then(() => {
         setFriendRequests(prev => prev.filter(req => req.id !== friendId))
       })
   }
@@ -76,9 +74,7 @@ export const FriendsList = props => {
         user_name: props.params.id,
         friend_name: friendId,
       })
-      .then(response => {
-        console.log(response)
-        // 友達リクエストリストを更新
+      .then(() => {
         setFriendRequests(prev => prev.filter(req => req.id !== friendId))
       })
   }

--- a/static-builder/src/js/pages/UserProfile.js
+++ b/static-builder/src/js/pages/UserProfile.js
@@ -11,7 +11,6 @@ export const UserProfile = props => {
   const [isEditing, setIsEditing] = Teact.useState(false)
   const [userData, setUserData] = Teact.useState(null)
   let changeUserName = ''
-  console.log(props.params.username)
   const onAccept = friendId => {
     userApi
       .acceptFriendRequest({
@@ -152,7 +151,6 @@ export const UserProfile = props => {
         }
       }
       const data = await response.json()
-      console.log('Avatar uploaded successfully:', data)
       setUserData(prevUserData => ({
         ...prevUserData,
         avatar_path: data.avatar_url,
@@ -182,7 +180,6 @@ export const UserProfile = props => {
           })
         } else if (response.status === 400) {
           const data = await response.json()
-          console.log(data)
           showErrorBanner({
             message: data.errors[0].message,
             onClose: () => {},
@@ -375,7 +372,6 @@ export const UserProfile = props => {
         throw new Error('Unknown error occurred')
       })
       .then(data => {
-        console.log(data)
         if (data) {
           setUserData(data)
         }

--- a/static-builder/src/js/pages/UserProfile.js
+++ b/static-builder/src/js/pages/UserProfile.js
@@ -115,7 +115,16 @@ export const UserProfile = () => {
             : null,
         ),
       ),
-      Teact.createElement('p', null, `Friends: ${userData.num_of_friends}`),
+      userData.display_name
+        ? Teact.createElement(
+            'a',
+            {
+              href: `/users/${userData.display_name}/friends`,
+              className: 'text-blue-500 hover:underline',
+            },
+            `Friends: ${userData.num_of_friends}`,
+          )
+        : Teact.createElement('p', null, `Friends: ${userData.num_of_friends}`),
     )
   }
 

--- a/static-builder/src/js/pages/UserProfile.js
+++ b/static-builder/src/js/pages/UserProfile.js
@@ -256,6 +256,7 @@ export const UserProfile = () => {
         throw new Error('Unknown error occurred')
       })
       .then(data => {
+        console.log(data)
         if (data) {
           setUserData(data)
         }
@@ -275,6 +276,29 @@ export const UserProfile = () => {
     )
   }
 
+  const friendButton = () => {
+    const relation = userData.relation_to_current_user
+    if (relation === 'self') return null
+    if (relation === 'friend')
+      return Teact.createElement(
+        'button',
+        { className: 'btn btn-danger btn-sm ms-3' },
+        'Unfriend',
+      )
+    if (relation === 'requesting')
+      return Teact.createElement(
+        'button',
+        { className: 'btn btn-info btn-sm ms-3' },
+        'Cancel Request Friend',
+      )
+    if (relation === 'request_received')
+      return Teact.createElement(
+        'button',
+        { className: 'btn btn-success btn-sm ms-3' },
+        'Accept',
+      )
+  }
+
   return HeaderWithTitleLayout(
     Teact.createElement(
       'div',
@@ -288,6 +312,7 @@ export const UserProfile = () => {
           { className: 'd-flex align-items-center' },
           renderAvatarSection(),
           renderProfileSection(),
+          friendButton(),
         ),
         Teact.createElement(
           'div',

--- a/static-builder/src/js/pages/UserProfile.js
+++ b/static-builder/src/js/pages/UserProfile.js
@@ -5,13 +5,13 @@ import { HeaderWithTitleLayout } from '@/js/layouts/HeaderWithTitleLayout'
 import { Teact } from '@/js/libs/teact'
 import { useNavigate } from '@/js/libs/router'
 
-export const UserProfile = () => {
+export const UserProfile = props => {
   const { showInfoBanner, showErrorBanner, banners } = useBanner()
   const navigate = useNavigate()
   const [isEditing, setIsEditing] = Teact.useState(false)
   const [userData, setUserData] = Teact.useState(null)
   let changeUserName = ''
-
+  console.log(props.params.username)
   const onAccept = friendId => {
     userApi
       .acceptFriendRequest({
@@ -351,7 +351,7 @@ export const UserProfile = () => {
   }
 
   Teact.useEffect(() => {
-    const userName = window.location.pathname.split('/').filter(Boolean).pop()
+    const userName = props.params.username
     userApi
       .getProfile(userName)
       .then(response => {
@@ -386,7 +386,7 @@ export const UserProfile = () => {
           onClose: () => {},
         }),
       )
-  }, [])
+  }, [props.params.username])
 
   if (!userData) {
     return HeaderWithTitleLayout(

--- a/static-builder/src/scss/styles.scss
+++ b/static-builder/src/scss/styles.scss
@@ -56,6 +56,14 @@
   border-radius: 50%;
 }
 
+.profile-icon {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}
+
+
+
 .hidden {
   display: none;
 }

--- a/static-builder/src/scss/styles.scss
+++ b/static-builder/src/scss/styles.scss
@@ -92,3 +92,15 @@
     transform: translateX(-50%) translateY(0);
   }
 }
+
+.empty-row td{
+  height: 0px; /* 通常の行と同じ高さに設定 */
+  background-color: transparent !important;
+  border-bottom-color: transparent !important; /* 罫線を透明に */
+  box-shadow: none !important; /* box-shadowを削除 */
+  padding: 0.0rem 0.5rem !important; /* paddingを0に設定 */
+}
+
+.empty-row:hover {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
（copilot summaryで要約）

# 「フレンド」機能の追加に関するプルリクエスト概要

このプルリクエストでは、ユーザーが友達関係を管理し、友達リクエストの送受信、友達関連データの閲覧を可能にする新しい「フレンド」機能をアプリケーションに導入します。また、この機能をサポートするためのユーザーモデルとフロントエンドの更新も含まれています。以下は、テーマ別にグループ化された最も重要な変更点です：

### バックエンド：フレンド機能の実装
* `user`、`friend`、`status`、`created_at` フィールドを含む友達関係を表す `Friend` モデルを持つ新しい Django アプリ `friend` を追加しました。このモデルはユーザーのペアの一意性を強制し、「保留中」、「承認済み」、「拒否」などのステータスをサポートします（`api/conf/app_friend/models.py`）。
* 友達リクエストの作成、友達のリスト表示、友達リクエストの取得のためのシリアライザーを導入しました（`api/conf/app_friend/serializers.py`）。
* 友達の一覧表示、友達リクエストの送信、リクエストの承認/拒否、友達の削除など、友達関連の操作を処理するAPIビューを追加しました（`api/conf/app_friend/views.py`）。

### バックエンド：ユーザーモデルの強化
* 友達関係へのより簡単なアクセスのために、`Friend` モデルを介して自身と多対多の関係を持つように `User` モデルを更新しました（`api/conf/app_user/models.py`）。
* 友達の数と現在のユーザーに対するユーザーの関係ステータスを含めるように `create_response` ユーティリティを修正しました（`api/conf/app_user/utils.py`）。

### バックエンド：ルーティングとAPIドキュメンテーション
* 友達の一覧表示、友達リクエストの管理、現在のユーザー情報の取得など、友達関連のエンドポイント用のルートを追加しました（`api/conf/app_user/user_urls.py`、`api/conf/app_user/auth_urls.py`）。
* 友達管理とユーザー情報取得のための新しいエンドポイントを含めるようにOpenAPIドキュメントを更新しました（`openapi.yaml`）。

### フロントエンド：ユーザーと友達の統合
* 新しい「現在のユーザー」APIエンドポイントから取得した現在のユーザーのアバターと名前を表示するように `Header` コンポーネントを強化しました（`static-builder/src/js/components/common/Header.js`）。
* 友達リストと一緒に友達リクエストを表示するように `FriendsTable` コンポーネントを更新しました（`static-builder/src/js/features/friends/FriendsTable.js`）。

### 設定とセットアップ
* プロジェクトで機能を有効にするために、`settings.py` と `dev/settings.py` の両方に新しい `friend` アプリを登録しました（`api/conf/project/settings.py`、`api/dev/settings.py`）。
* セットアッププロセス中に `friend` アプリを含めるように `Dockerfile` を更新しました（`api/Dockerfile`）。