### PR TITLE
トーナメント一覧（参加待ち）」の画面に係る実装

### DIFF
--- a/api/conf/tournament/urls.py
+++ b/api/conf/tournament/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import TournamentViewSet, TournamentPlayerViewSet
+from .views import TournamentViewSet, TournamentPlayerViewSet, JoinTournamentView
 
 router = DefaultRouter()
 router.register(r'tournament', TournamentViewSet)
 router.register(r'player', TournamentPlayerViewSet)
 
 urlpatterns = [
-    path('', include(router.urls)),
+    path('dev/', include(router.urls)),
+    path('/', JoinTournamentView.as_view(), name='join_tournament')
 ]

--- a/api/conf/tournament/urls.py
+++ b/api/conf/tournament/urls.py
@@ -8,5 +8,5 @@ router.register(r'player', TournamentPlayerViewSet)
 
 urlpatterns = [
     path('dev/', include(router.urls)),
-    path('/', JoinTournamentView.as_view(), name='join_tournament')
+    path('', JoinTournamentView.as_view(), name='join_tournament')
 ]

--- a/api/conf/tournament/utils.py
+++ b/api/conf/tournament/utils.py
@@ -1,4 +1,15 @@
 from rest_framework.exceptions import ValidationError
 from django.db.models import F
-
+from room.utils import RoomKey
 from .models import Tournament, TournamentPlayer
+
+def get_latest_unfinished_tournament(tournament_type):
+    """
+    is_finished=False かつ type=tournament_type の最新のトーナメントを取得
+    """
+    return Tournament.objects.filter(
+        is_finished=False,
+        type=tournament_type
+    ).order_by('-id').first()
+
+

--- a/api/conf/tournament/views.py
+++ b/api/conf/tournament/views.py
@@ -54,9 +54,9 @@ class JoinTournamentView(APIView):
             with transaction.atomic():
 
                 existing_participation = TournamentPlayer.objects.filter(
-                user=user,
-                is_finished=False,
-                type=tournament_type
+                    user=user,
+                    tournament__is_finished=False,  # tournament経由でアクセス
+                    tournament__type=tournament_type  # tournament経由でアクセス
                 ).select_related('tournament').first()
 
                 if existing_participation:

--- a/api/conf/tournament/views.py
+++ b/api/conf/tournament/views.py
@@ -55,8 +55,8 @@ class JoinTournamentView(APIView):
 
                 existing_participation = TournamentPlayer.objects.filter(
                 user=user,
-                tournament__is_finished=False,
-                tournament__type=tournament_type
+                is_finished=False,
+                type=tournament_type
                 ).select_related('tournament').first()
 
                 if existing_participation:

--- a/api/conf/tournament/views.py
+++ b/api/conf/tournament/views.py
@@ -1,14 +1,27 @@
 import random
+import redis
 from rest_framework import viewsets
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+import traceback
+
+
+from room.utils import RoomKey
+from room.models import RoomMembers
+
+from user.utils import get_user_by_auth
+from user.exceptions import AuthError
+
+
 from django.utils.decorators import method_decorator
+from django.db import transaction
 
 from .models import Tournament, TournamentPlayer
 from utils.decorators import admin_only
+from .utils import get_latest_unfinished_tournament
 
 # start: ユースケースでは本来必要ないが、データの確認のために追加
 @method_decorator(admin_only, name = 'dispatch')
@@ -19,3 +32,175 @@ class TournamentViewSet(viewsets.ModelViewSet):
 class TournamentPlayerViewSet(viewsets.ModelViewSet):
     queryset = TournamentPlayer.objects.all()
 # :end
+
+class JoinTournamentView(APIView):
+    def __init__(self):
+        self.redis_client = redis.StrictRedis(
+            host="in_memory_db",
+            port=6379,
+            db=0,
+            decode_responses=False  # 文字列として取得
+        )
+    def post(self, request):
+        tournament_type = request.data.get('type')
+        if tournament_type not in [4, 8]:  # 4P または 8P のみ許可
+            return Response({'error': 'Invalid tournament type'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            user = get_user_by_auth(request.headers.get('Authorization'))
+            if not user:
+                raise AuthError('Authorization header is required.')
+
+            with transaction.atomic():
+
+                existing_participation = TournamentPlayer.objects.filter(
+                user=user,
+                tournament__is_finished=False,
+                tournament__type=tournament_type
+                ).select_related('tournament').first()
+
+                if existing_participation:
+                    # 既に参加中のトーナメントがある場合、その情報を返す
+                    tournament = existing_participation.tournament
+                    room_data = self._get_room_data(tournament)
+
+                    response_data = {
+                        'id': tournament.id,
+                        'tournament_type': tournament.type,
+                        'room_id': f"tournament_{tournament.id}",
+                        'current_players': room_data.get('entry_count', 1),
+                        'max_players': tournament.type,
+                        'is_full': int(room_data.get('entry_count', 1)) >= tournament.type,
+                        'user_entry_number': existing_participation.entry_number,
+                        'message': 'Already joined this tournament'
+                    }
+
+                    return Response(response_data, status=status.HTTP_200_OK)
+
+                tournament = get_latest_unfinished_tournament(tournament_type)
+
+
+                if tournament:
+                    # 既存のトーナメントに参加する場合
+                    room_type = self._get_room_type(tournament_type)
+                    current_count = RoomKey.increment_entry_count(
+                        self.redis_client,
+                        room_type,
+                        tournament.id
+                    )
+
+                    if current_count == -1:
+                        # 定員オーバーまたはルームが存在しない場合、新しいトーナメントを作成
+                        tournament = self._create_new_tournament(tournament_type, user)
+                        room_data = self._get_room_data(tournament)
+                    else:
+                        # 既存のトーナメントに参加
+                        self._add_user_to_existing_tournament(tournament, user)
+                        room_data = self._get_room_data(tournament)
+                else:
+                    # 新しいトーナメントを作成
+                    tournament = self._create_new_tournament(tournament_type, user)
+                    room_data = self._get_room_data(tournament)
+
+                # 3. ROOM_MEMBERSデータを作成する
+                RoomMembers.objects.get_or_create(
+                    room_id=f"tournament_{tournament.id}",
+                    user=user
+                )
+
+                response_data = {
+                    'id': tournament.id,
+                    'tournament_type': tournament.type,
+                    'room_id': f"tournament_{tournament.id}",
+                    'current_players': room_data.get('entry_count', 1),
+                    'max_players': tournament.type,
+                    'is_full': int(room_data.get('entry_count', 1)) >= tournament.type,
+                    'user_entry_number': self._get_user_entry_number(tournament, user)
+                }
+
+                return Response(response_data, status=status.HTTP_201_CREATED)
+
+        except AuthError as e:
+            with open('error.log', 'a') as f:
+                f.write(f" AuthError: {str(e)}\n")
+                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_401_UNAUTHORIZED
+            )
+        except ValidationError as e:
+            with open('error.log', 'a') as f:
+                f.write(f" ValidationError: {str(e)}\n")
+                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        except Exception as e:
+            with open('error.log', 'a') as f:
+                f.write(f" Exception: {str(e)}\n")
+                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
+            return Response(
+                {'error': 'Internal server error'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    def _get_room_type(self, tournament_type):
+        """トーナメントタイプに基づいてルームタイプを決定"""
+        return f"WAITING_{tournament_type}P"
+
+    def _create_new_tournament(self, tournament_type, user):
+            """新しいトーナメントを作成"""
+            # TOURNAMENTSデータを作成
+            tournament = Tournament.create(type=tournament_type)
+
+            # ROOMSデータを作成（Redis）
+            room_type = self._get_room_type(tournament_type)
+            RoomKey.create_room(
+                self.redis_client,
+                room_type,
+                tournament.id,
+                tournament_id=tournament.id
+            )
+
+            # 最初のプレイヤーを追加
+            TournamentPlayer.objects.create(
+                tournament=tournament,
+                user=user,
+                entry_number=0,
+                round=1
+            )
+
+            return tournament
+
+    def _add_user_to_existing_tournament(self, tournament, user):
+        """既存のトーナメントにユーザーを追加"""
+        # 既に参加しているかチェック
+        if TournamentPlayer.objects.filter(tournament=tournament, user=user).exists():
+            raise ValidationError("User already joined this tournament")
+
+        # 次のエントリー番号を取得
+        existing_players_count = TournamentPlayer.objects.filter(tournament=tournament).count()
+
+        if existing_players_count >= tournament.type:
+            raise ValidationError("Tournament is already full")
+
+        TournamentPlayer.objects.create(
+            tournament=tournament,
+            user=user,
+            entry_number=existing_players_count,
+            round=1
+        )
+
+    def _get_room_data(self, tournament):
+        """Redisからルームデータを取得"""
+        room_type = self._get_room_type(tournament.type)
+        return RoomKey.get_room(self.redis_client, room_type, tournament.id)
+
+    def _get_user_entry_number(self, tournament, user):
+        """ユーザーのエントリー番号を取得"""
+        try:
+            player = TournamentPlayer.objects.get(tournament=tournament, user=user)
+            return player.entry_number
+        except TournamentPlayer.DoesNotExist:
+            return None

--- a/api/conf/tournament/views.py
+++ b/api/conf/tournament/views.py
@@ -121,25 +121,16 @@ class JoinTournamentView(APIView):
                 return Response(response_data, status=status.HTTP_201_CREATED)
 
         except AuthError as e:
-            with open('error.log', 'a') as f:
-                f.write(f" AuthError: {str(e)}\n")
-                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
             return Response(
                 {'error': str(e)},
                 status=status.HTTP_401_UNAUTHORIZED
             )
         except ValidationError as e:
-            with open('error.log', 'a') as f:
-                f.write(f" ValidationError: {str(e)}\n")
-                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
             return Response(
                 {'error': str(e)},
                 status=status.HTTP_400_BAD_REQUEST
             )
         except Exception as e:
-            with open('error.log', 'a') as f:
-                f.write(f" Exception: {str(e)}\n")
-                f.write(f"Stacktrace: {traceback.format_exc()}\n\n")
             return Response(
                 {'error': 'Internal server error'},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/api/conf/tournament/views.py
+++ b/api/conf/tournament/views.py
@@ -148,9 +148,8 @@ class JoinTournamentView(APIView):
             # ROOMSデータを作成（Redis）
             room_type = self._get_room_type(tournament_type)
             RoomKey.create_room(
-                self.redis_client,
-                room_type,
-                tournament.id,
+                room_type=room_type,
+                table_id=tournament.id,
                 tournament_id=tournament.id
             )
 
@@ -186,7 +185,7 @@ class JoinTournamentView(APIView):
     def _get_room_data(self, tournament):
         """Redisからルームデータを取得"""
         room_type = self._get_room_type(tournament.type)
-        return RoomKey.get_room(self.redis_client, room_type, tournament.id)
+        return RoomKey.get_room(room_type, tournament.id)
 
     def _get_user_entry_number(self, tournament, user):
         """ユーザーのエントリー番号を取得"""

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -444,6 +444,74 @@ paths:
               schema:
                 $ref: "#/components/schemas/error_response"
 
+  /api/tournaments/:
+    post:
+      tags:
+        - remote_players
+      summary: トーナメント参加
+      security:
+        - bearerAuth: []
+      description: |
+        指定されたタイプのトーナメントに参加します。
+        - 既に参加中のトーナメントがある場合は、その情報を返します（200）
+        - 新規参加の場合は、新しいトーナメントまたは既存の空きがあるトーナメントに参加します（201）
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/tournament_join_request"
+      responses:
+        "200":
+          description: 既に参加中のトーナメント情報
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/tournament_join_response"
+                  - type: object
+                    properties:
+                      message:
+                        type: string
+                        example: "Already joined this tournament"
+        "201":
+          description: トーナメント参加成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/tournament_join_response"
+        "400":
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_single_response"
+              examples:
+                invalid_type:
+                  summary: 無効なトーナメントタイプ
+                  value:
+                    error: "Invalid tournament type"
+                tournament_full:
+                  summary: トーナメント満員
+                  value:
+                    error: "Tournament is already full"
+        "401":
+          description: 認証エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_single_response"
+              example:
+                error: "Authorization header is required."
+        "500":
+          description: サーバー内部エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_single_response"
+              example:
+                error: "Internal server error"
+
 components:
   parameters:
     display_name:
@@ -842,6 +910,59 @@ components:
             losses: 1
             win_rate: 50.0
 
+    tournament_join_request:
+          type: object
+          properties:
+            type:
+              type: integer
+              enum: [4, 8]
+              description: トーナメントタイプ（4人または8人）
+          required:
+            - type
+          example:
+            type: 4
+
+    tournament_join_response:
+        type: object
+        properties:
+          id:
+            type: integer
+            description: トーナメントID
+          tournament_type:
+            type: integer
+            description: トーナメントタイプ（4人または8人）
+          room_id:
+            type: string
+            description: ルームID
+          current_players:
+            type: string
+            description: 現在の参加者数
+          max_players:
+            type: integer
+            description: 最大参加者数
+          is_full:
+            type: boolean
+            description: ルームが満員かどうか
+          user_entry_number:
+            type: integer
+            description: ユーザーのエントリー番号
+        required:
+          - id
+          - tournament_type
+          - room_id
+          - current_players
+          - max_players
+          - is_full
+          - user_entry_number
+        example:
+          id: 1
+          tournament_type: 4
+          room_id: "tournament_1"
+          current_players: "2"
+          max_players: 4
+          is_full: false
+          user_entry_number: 1
+
     error_response:
       type: object
       properties:
@@ -865,3 +986,14 @@ components:
             message: "ログイン名が不正です。"
           - field: "password"
             message: "パスワードが不正です。"
+
+    error_single_response:
+      type: object
+      properties:
+        error:
+          type: string
+          description: "単一エラーメッセージ"
+      required:
+        - error
+      example:
+        error: "Invalid tournament type"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,7 @@ info:
   contact:
     name: とらせん
     url: https://www.example.com/support
-    email: support@example.com    
+    email: support@example.com
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
@@ -392,7 +392,7 @@ components:
       description: フレンドの表示名
       schema:
         type: string
-  
+
   securitySchemes:
     bearerAuth:
       type: http
@@ -562,7 +562,7 @@ components:
         password_confirmation: "password1"
         secret_question: "母親の旧姓は？"
         secret_answer: "石川"
-    
+
     user_passwordreset_request:
       type: object
       properties:
@@ -594,7 +594,7 @@ components:
         - login_name
       example:
         login_name: "user1"
-    
+
     secret_question_response:
       type: object
       properties:
@@ -604,7 +604,7 @@ components:
         - secret_question
       example:
         secret_question: "母親の旧姓は？"
-    
+
     friends_response:
       type: object
       properties:
@@ -632,7 +632,7 @@ components:
             is_online: false
           - friend_name: "user4"
             is_online: true
-    
+
     user_patch_request:
       type: object
       properties:
@@ -773,7 +773,7 @@ components:
             wins: 1
             losses: 1
             win_rate: 50.0
-    
+
     error_response:
       type: object
       properties:

--- a/static-builder/src/js/infrastructures/api/tournamentApi.js
+++ b/static-builder/src/js/infrastructures/api/tournamentApi.js
@@ -24,7 +24,25 @@ function createLocalTournament(data) {
   })
 }
 
+function joinRemoteTournament(data) {
+  return api.post('/api/tournaments/', data).then(async response => {
+    if (!response.ok) {
+      const errData = await response.json()
+      throw new Error(errData.error || 'Unknown error occurred')
+    }
+    const responseData = await response.json()
+    console.log('joinRemoteTournament responseData:', responseData)
+    if (!responseData.id) {
+      throw new Error('Tournament ID is missing in the response')
+    }
+
+    return responseData
+  })
+}
+
 export const tournamentsApi = {
   fetchLocalTournament,
   createLocalTournament,
+
+  joinRemoteTournament,
 }

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -13,7 +13,7 @@ import { PasswordReset } from '@/js/pages/PasswordReset'
 import { SimpleGameLocal } from '@/js/pages/SimpleGameLocal'
 import { TournamentsBracket } from '@/js/pages/TournamentsBracket'
 import { TournamentsDisplayName } from '@/js/pages/TournamentsDisplayName'
-
+import { RemoteSimpleList } from './pages/RemoteSimpleList'
 function App() {
   console.log('App rendered')
   Teact.useEffect(() => {
@@ -46,10 +46,14 @@ function App() {
     }),
     Route({
       path: '/remote/simple',
-      component: Home, //遷移先のページは仮置き
+      component: RemoteSimpleList,
     }),
     Route({
       path: '/remote/tournament',
+      component: Home, //遷移先のページは仮置き
+    }),
+    Route({
+      path: '/remote/tournament/:id',
       component: Home, //遷移先のページは仮置き
     }),
     Route({

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -13,7 +13,10 @@ import { PasswordReset } from '@/js/pages/PasswordReset'
 import { SimpleGameLocal } from '@/js/pages/SimpleGameLocal'
 import { TournamentsBracket } from '@/js/pages/TournamentsBracket'
 import { TournamentsDisplayName } from '@/js/pages/TournamentsDisplayName'
-import { RemoteSimpleList } from './pages/RemoteSimpleList'
+import { TournamentsGame } from '@/js/pages/TournamentsGame'
+import { TournamentsIndex } from '@/js/pages/TournamentsIndex'
+import { RemoteTournamentsIndex } from '@/js/pages/RemoteTournamentsIndex'
+
 function App() {
   console.log('App rendered')
   Teact.useEffect(() => {
@@ -46,11 +49,11 @@ function App() {
     }),
     Route({
       path: '/remote/simple',
-      component: RemoteSimpleList,
+      component: Home,
     }),
     Route({
       path: '/remote/tournament',
-      component: Home, //遷移先のページは仮置き
+      component: RemoteTournamentsIndex, //遷移先のページは仮置き
     }),
     Route({
       path: '/remote/tournament/:id',

--- a/static-builder/src/js/main.js
+++ b/static-builder/src/js/main.js
@@ -13,8 +13,6 @@ import { PasswordReset } from '@/js/pages/PasswordReset'
 import { SimpleGameLocal } from '@/js/pages/SimpleGameLocal'
 import { TournamentsBracket } from '@/js/pages/TournamentsBracket'
 import { TournamentsDisplayName } from '@/js/pages/TournamentsDisplayName'
-import { TournamentsGame } from '@/js/pages/TournamentsGame'
-import { TournamentsIndex } from '@/js/pages/TournamentsIndex'
 import { RemoteTournamentsIndex } from '@/js/pages/RemoteTournamentsIndex'
 
 function App() {

--- a/static-builder/src/js/pages/RemoteSimpleList.js
+++ b/static-builder/src/js/pages/RemoteSimpleList.js
@@ -1,0 +1,55 @@
+import { DefaultButton } from '@/js/components/ui/button'
+import { HeaderWithTitleLayout } from '@/js/layouts/HeaderWithTitleLayout'
+import { useNavigate } from '@/js/libs/router'
+import { Teact } from '@/js/libs/teact'
+import { tournamentsApi } from '../infrastructures/api/tournamentApi'
+
+export const RemoteSimpleList = () => {
+  const navigate = useNavigate()
+
+  return HeaderWithTitleLayout(
+    Teact.createElement(
+      'div',
+      { className: 'container vh-100' },
+      Teact.createElement(
+        'h3',
+        { className: 'mb-5 text-center text-light' },
+        'Choose Tournament Mode',
+      ),
+      Teact.createElement(
+        'div',
+        { className: 'd-grid gap-2 col-3 mx-auto' },
+        DefaultButton({
+          text: 'Join 4P Tournament ',
+          onClick: async () => {
+            try {
+              const response = await tournamentsApi.joinRemoteTournament({
+                type: 4,
+              })
+              const tournamentId = response.id
+
+              navigate(`/remote/tournament/${tournamentId}`)
+            } catch (error) {
+              console.error('Failed to join tournament:', error.message)
+            }
+          },
+        }),
+        DefaultButton({
+          text: 'Join 8P Tournament ',
+          onClick: async () => {
+            try {
+              const response = await tournamentsApi.joinRemoteTournament({
+                type: 8,
+              })
+              const tournamentId = response.id
+
+              navigate(`/remote/tournament/${tournamentId}`)
+            } catch (error) {
+              console.error('Failed to join tournament:', error.message)
+            }
+          },
+        }),
+      ),
+    ),
+  )
+}

--- a/static-builder/src/js/pages/RemoteTournamentsIndex.js
+++ b/static-builder/src/js/pages/RemoteTournamentsIndex.js
@@ -4,7 +4,7 @@ import { useNavigate } from '@/js/libs/router'
 import { Teact } from '@/js/libs/teact'
 import { tournamentsApi } from '../infrastructures/api/tournamentApi'
 
-export const RemoteSimpleList = () => {
+export const RemoteTournamentsIndex = () => {
   const navigate = useNavigate()
 
   return HeaderWithTitleLayout(


### PR DESCRIPTION
<!-- github copilotへ コードレビューの指示：レビューは必ず日本語で絵文字多めで楽しそうな感じで実施してください💐  -->

### 実装したこと

* トーナメント一覧（参加待ち）」の画面を作成する `/remote/simple`
* join ⚪︎p tournamentを押下した時にapi/tournaments APIにトーナメントの種類のデータを渡す
* トーナメントidが返ってきたら、api/tournaments/{:id}を叩いてトーナメント開催待ち画面にリダイレクトする
(トーナメント開催待ち画面は実装前なので、api/tournaments/{:id}がHomeを表示するように仮置きしています）

### 検証内容（例）
#### トーナメントが正常に作られることを確かめる
a, b, c, d, eの５人のユーザーを作る
aにログインし、「Play Remote」→「Join 4P Tournament 」を押下する
Tournamenstテーブルに新たにトーナメントが作成されることを確認する
Tounament Playersテーブルを確認し、aがトーナメントの参加者として追加されていることを確認する

b, c, d, eまで同様にこの順で４Pトーナメントに登録する
b, c, dがトーナメント参加する時、aと同じトーナメントに順に追加されることを確認する
eがトーナメント参加する時、新たにトーナメントが作成されることを確認する

#### 参加中のトーナメントがあるときは、そのトーナメントidを返すことを確かめる
上記の検証後、aにログインし、「Play Remote」→「Join 4P Tournament 」を押下する
Tournamentsテーブル、Tournament Playersテーブルに新たに何も追加されないことを確認する

#### apiを叩いて確かめてみたい場合
`docker exec -it api /bin/bash`


ユーザーaを作る
```
curl -X POST "http://localhost:8000/api/users/" \
  -H "Content-Type: application/json" \
  -d '{
    "login_name": "a",
    "password": "a",
    "display_name": "a",
    "secret_question": "a",
    "secret_answer": "a"
  }'
```

ユーザーaの認証情報を使ってトーナメント参加する
```
curl -X POST "http://localhost:8000/api/tournaments/" \
  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzQ4NDg2OTQ4LCJpYXQiOjE3NDU4OTQ5NDgsImp0aSI6ImFmZjk3NzEwNTIzOTQ5MDRiZjNiYTg2MmFjZjIwMDM1IiwidXNlcl9pZCI6MX0.X8qI4mGltlHlM8yDHD8UgVTretGjQ9PCyn1tRCDaPzg" \
  -H "Content-Type: application/json" \
  -d '{"type": 4}' \
  -v
```
トーナメントへの参加登録が成功した場合のレスポンス例
```
{"id":1,"tournament_type":4,"room_id":"tournament_1","current_players":1,"max_players":4,"is_full":false,"user_entry_number":0}
```

### 実装していないこと
４Pと８Pのトーナメントに同時に参加できてしまう。これは今後直す必要があるかもしれない
