### PR TITLE
シンプル対戦画面のAPI POSTメソッド(Create)を作成する

### DIFF
--- a/api/conf/match/simple_match_urls.py
+++ b/api/conf/match/simple_match_urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import SimpleMatchView
+from .views import SimpleMatchView, SimpleMatchCreateView
 
 urlpatterns = [
     path('', SimpleMatchView.as_view(), name = 'simple-match'),
+    path('create/', SimpleMatchCreateView.as_view(), name = 'simple-match-create'),
 ]

--- a/api/conf/match/tests.py
+++ b/api/conf/match/tests.py
@@ -101,9 +101,9 @@ class MatchAPITestCase(APITestCase):
         for item in response.data:
             self.assertIsInstance(item['match_id'], int)
             self.assertIsInstance(item['display_name'], str)
-            print(item)
+            # print(item) # for debugging purposes
 
-    def test_post_simple_match(self):
+    def test_post_simple_match_create(self):
         # Redisの初期化
         get_redis().flushdb()
 
@@ -115,13 +115,13 @@ class MatchAPITestCase(APITestCase):
         )
         token = access_response.json()['access_token']
         self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
-        url = reverse('simple-match')
+        url = reverse('simple-match-create')
         # 参加待ちのシンプル対戦ルームが5つ未満の時
         create_room_simple(2)
         response = self.client.post(url, {'type': 'remote'})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIsInstance(response.data, dict)
-        self.assertIn('room_id', response.data)
+        self.assertIn('match_id', response.data)
         # print(response.data) # for debugging purposes
         # 参加待ちのシンプル対戦ルームが5つ以上の時
         for i in range(5):

--- a/api/conf/match/tests.py
+++ b/api/conf/match/tests.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 from django.core.exceptions import ValidationError
 
 from .models import Match, MatchDetail
-from room.tests import create_test_room_members_simple
+from utils.redis_client import get_redis
+from room.tests import create_room_simple, create_test_room_members_simple
 from user.tests import create_test_user, create_test_user_4, create_test_user_8
 from tournament.tests import create_test_tournament_4, create_test_tournament_8
 
@@ -101,3 +102,29 @@ class MatchAPITestCase(APITestCase):
             self.assertIsInstance(item['match_id'], int)
             self.assertIsInstance(item['display_name'], str)
             print(item)
+
+    def test_post_simple_match(self):
+        # Redisの初期化
+        get_redis().flushdb()
+
+        create_test_user('a', 'a', 'a', 'a', 'a')
+        access_response = self.client.post(
+            reverse('login'),
+            {'login_name': 'a', 'password': 'a'},
+            format='json'
+        )
+        token = access_response.json()['access_token']
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        url = reverse('simple-match')
+        # 参加待ちのシンプル対戦ルームが5つ未満の時
+        create_room_simple(2)
+        response = self.client.post(url, {'type': 'remote'})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIsInstance(response.data, dict)
+        self.assertIn('room_id', response.data)
+        # print(response.data) # for debugging purposes
+        # 参加待ちのシンプル対戦ルームが5つ以上の時
+        for i in range(5):
+            create_room_simple(i + 3)
+        response = self.client.post(url, {'type': 'remote'})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/api/conf/match/views.py
+++ b/api/conf/match/views.py
@@ -9,10 +9,11 @@ from .models import Match, MatchDetail
 from .utils import create_simple_match_response
 from user.utils import get_user_by_auth
 from user.exceptions import AuthError
+from room.models import RoomMembers
 from room.utils import RoomKey
 from utils.decorators import admin_only
 
-END_OF_GAME_SCORE = 11
+SIMPLE_WAITING_ROOM_LIMIT = 5
 
 # start: ユースケースでは本来必要ないが、データの確認のために追加
 @method_decorator(admin_only, name = 'dispatch')
@@ -48,3 +49,27 @@ class SimpleMatchView(APIView):
                 return Response(create_simple_match_response(waiting_simple_room_keys), status = status.HTTP_200_OK)
             except AuthError as e:
                 return Response({"error": str(e)}, status = status.HTTP_401_UNAUTHORIZED)
+        else:
+            return Response({"error": "Invalid match type."}, status = status.HTTP_400_BAD_REQUEST)
+
+    def post(self, request):
+        match_type = request.data.get('type')
+        if match_type != 'remote':
+            return Response({"error": "Invalid match type."}, status = status.HTTP_400_BAD_REQUEST)
+        try:
+            user = get_user_by_auth(request.headers.get('Authorization'))
+            if not user:
+                raise AuthError('Authorization header is incorrect.')
+            waiting_simple_room_keys = RoomKey.get_keys_by_type_and_entry_count("SIMPLE", 2)
+            if len(waiting_simple_room_keys) < SIMPLE_WAITING_ROOM_LIMIT:
+                match = Match.objects.create()
+                room_key = RoomKey.create_room(room_type = "SIMPLE", table_id = match.id, match_id = match.id)
+                RoomMembers.objects.create(room_id = room_key, user = user)
+                return Response({"room_id": room_key}, status = status.HTTP_201_CREATED)
+            else:
+                return Response({"error": "Waiting room limit reached."}, status = status.HTTP_400_BAD_REQUEST)
+
+        except AuthError as e:
+            return Response({"error": str(e)}, status = status.HTTP_401_UNAUTHORIZED)
+        except DatabaseError as e:
+            return Response({"error": "Database error occurred."}, status = status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/api/conf/match/views.py
+++ b/api/conf/match/views.py
@@ -52,6 +52,7 @@ class SimpleMatchView(APIView):
         else:
             return Response({"error": "Invalid match type."}, status = status.HTTP_400_BAD_REQUEST)
 
+class SimpleMatchCreateView(APIView):
     def post(self, request):
         match_type = request.data.get('type')
         if match_type != 'remote':
@@ -65,7 +66,7 @@ class SimpleMatchView(APIView):
                 match = Match.objects.create()
                 room_key = RoomKey.create_room(room_type = "SIMPLE", table_id = match.id, match_id = match.id)
                 RoomMembers.objects.create(room_id = room_key, user = user)
-                return Response({"room_id": room_key}, status = status.HTTP_201_CREATED)
+                return Response({"match_id": match.id}, status = status.HTTP_201_CREATED)
             else:
                 return Response({"error": "Waiting room limit reached."}, status = status.HTTP_400_BAD_REQUEST)
 

--- a/api/conf/room/tests.py
+++ b/api/conf/room/tests.py
@@ -11,6 +11,8 @@ from user.tests import create_test_user, create_test_user_4
 def create_room_simple(table_id):
     room_type = "SIMPLE"
     table_id = table_id
+    # The match_id is set to the same value as table_id because, for SIMPLE rooms, 
+    # the table_id uniquely identifies both the table and the match.
     match_id = table_id
     tournament_id = None
     return RoomKey.create_room(room_type, table_id, match_id, tournament_id)

--- a/api/conf/room/tests.py
+++ b/api/conf/room/tests.py
@@ -8,10 +8,10 @@ from user.tests import create_test_user, create_test_user_4
 #---------------
 # Helper function to create Data
 #---------------
-def create_room_simple():
+def create_room_simple(table_id):
     room_type = "SIMPLE"
-    table_id = 1
-    match_id = 1
+    table_id = table_id
+    match_id = table_id
     tournament_id = None
     return RoomKey.create_room(room_type, table_id, match_id, tournament_id)
 
@@ -38,7 +38,7 @@ def create_room_waiting_8p():
 
 def create_test_room_members_simple():
     user = create_test_user('z', 'z', 'z', 'z', 'z')
-    create_room_simple()
+    create_room_simple(1)
     return RoomMembers.objects.create(room_id = 'room:SIMPLE:1', user = user)
 
 def create_test_room_members_4():

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -85,7 +85,7 @@ paths:
     post:
       tags:
         - simple_play
-      summary: 待機中の対戦に参加
+      summary: 対戦待ちルームの作成
       description: |
         自分の対戦待ちルームを作成します。クエリパラメーターは不要ですが、bodyに``type: remote``を含みます。
         JWT認証が必要です。レスポンスには、ゲーム画面への遷移に必要な `match_id` を含みます。

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,13 +81,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/error_response"
 
+  /api/simple-matches/create:
     post:
       tags:
         - simple_play
       summary: 待機中の対戦に参加
       description: |
-        参加待ちの対戦（リモート）情報を取得します。クエリパラメーターは不要ですが、bodyに``type: remote``を含みます。
-        JWT認証が必要です。レスポンスには、参加用に必要な `ROOM.id` を含みます。
+        自分の対戦待ちルームを作成します。クエリパラメーターは不要ですが、bodyに``type: remote``を含みます。
+        JWT認証が必要です。レスポンスには、ゲーム画面への遷移に必要な `match_id` を含みます。
       security:
         - bearerAuth: []
       requestBody:
@@ -112,11 +113,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  room_id:
-                    type: string
-                    description: 参加用のルームID
+                  match_id:
+                    type: integer
+                    description: ゲーム画面のURIの一部として使用されるマッチID
               example:
-                room_id: "room:SIMPLE:1"
+                match_id: 12345
         "401":
           description: 認証エラー(JWTトークンが無効または未提供)
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,6 +81,49 @@ paths:
               schema:
                 $ref: "#/components/schemas/error_response"
 
+    post:
+      tags:
+        - simple_play
+      summary: 待機中の対戦に参加
+      description: |
+        参加待ちの対戦（リモート）情報を取得します。クエリパラメーターは不要ですが、bodyに``type: remote``を含みます。
+        JWT認証が必要です。レスポンスには、参加用に必要な `ROOM.id` を含みます。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum: [remote]
+              required:
+                - type
+            example:
+              type: remote
+      responses:
+        "200":
+          description: ROOMの情報
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  room_id:
+                    type: string
+                    description: 参加用のルームID
+              example:
+                room_id: "room:SIMPLE:1"
+        "401":
+          description: 認証エラー(JWTトークンが無効または未提供)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_response"
+
   /api/auth/login:
     post:
       tags:


### PR DESCRIPTION
# レビュー方法
主なもの

- [ ] openapi.yamlの記述がmiroと同じであること（エンドポイントURIとレスポンスデータの内容）
- [ ] ~.yamlとmatch/test.pyの要求するデータ内容が同じであること
- [ ] post(Create)のビジネスロジックがmiroと同じであること
- [ ] ルートディレクトリでmakeして、その他の動作に失敗がないこと

# 注意点
Djangoに記述されているテストケースは、GitHubアクションズで自動実行されるようになりました

<!-- github copilotへ コードレビューの指示：レビューは必ず日本語で絵文字多めで楽しそうな感じで実施してください💐  -->
