### PR TITLE
リモートシンプル対戦一覧画面のPOSTメソッド（Join）を作成する

### DIFF
--- a/api/conf/match/simple_match_urls.py
+++ b/api/conf/match/simple_match_urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import SimpleMatchView, SimpleMatchCreateView
+from .views import SimpleMatchView, SimpleMatchCreateView, SimpleMatchJoinView
 
 urlpatterns = [
     path('', SimpleMatchView.as_view(), name = 'simple-match'),
     path('create/', SimpleMatchCreateView.as_view(), name = 'simple-match-create'),
+    path('join/', SimpleMatchJoinView.as_view(), name = 'simple-match-join'),
 ]

--- a/api/conf/match/utils.py
+++ b/api/conf/match/utils.py
@@ -1,3 +1,4 @@
+from .models import Match, MatchDetail
 from room.models import RoomMembers
 from room.utils import RoomKey
 
@@ -16,3 +17,30 @@ def create_simple_match_response(waiting_simple_room_keys):
             'display_name': display_name
         })
     return response_data
+
+def try_join_match(match_id, user):
+    try:
+        match = Match.objects.get(id = match_id)
+        if match.is_finished:
+            return {"error": "Match is already finished."}, False
+        tournamant_id = match.tournament_id
+        if tournamant_id is None:
+            room_data = RoomKey.get_room(room_type = "SIMPLE", table_id = match_id)
+            room_id = RoomKey.generate_key(room_type = "SIMPLE", table_id = match_id)
+        else:
+            room_data = RoomKey.get_room(room_type = "TOURNAMENT_MATCH", table_id = match_id)
+            room_id = RoomKey.generate_key(room_type = "TOURNAMENT_MATCH", table_id = match_id, tournament_id = tournamant_id)
+        if not room_data:
+            return {"error": "Room does not exist."}, False
+        entry_count = RoomKey.increment_entry_count(room_type = room_data["type"], table_id = match_id)
+        if entry_count == -1:
+            return {"error": "Match is full."}, False
+        RoomMembers.objects.create(room_id = room_id, user = user)
+        room_members = RoomMembers.objects.filter(room_id = room_id)
+        if len(room_members) != 2:
+            return {"error": "RoomMembers count does not expected."}, False
+        for member in room_members:
+            MatchDetail.objects.create(match = match, user = member.user)
+        return {"match_id": match_id}, True     
+    except Match.DoesNotExist:
+        return {"error": "Match does not exist."}, False

--- a/api/conf/match/utils.py
+++ b/api/conf/match/utils.py
@@ -38,7 +38,7 @@ def try_join_match(match_id, user):
         RoomMembers.objects.create(room_id = room_id, user = user)
         room_members = RoomMembers.objects.filter(room_id = room_id)
         if len(room_members) != 2:
-            return {"error": "RoomMembers count does not expected."}, False
+            return {"error": "RoomMembers count is not as expected."}, False
         for member in room_members:
             MatchDetail.objects.create(match = match, user = member.user)
         return {"match_id": match_id}, True     

--- a/api/conf/match/utils.py
+++ b/api/conf/match/utils.py
@@ -1,3 +1,5 @@
+from django.db import DatabaseError
+
 from .models import Match, MatchDetail
 from room.models import RoomMembers
 from room.utils import RoomKey
@@ -44,3 +46,6 @@ def try_join_match(match_id, user):
         return {"match_id": match_id}, True     
     except Match.DoesNotExist:
         return {"error": "Match does not exist."}, False
+    except DatabaseError:
+        RoomKey.decrement_entry_count(room_type = room_data["type"], table_id = match_id)
+        return {"error": "Database error occurred."}, False

--- a/api/conf/room/tests.py
+++ b/api/conf/room/tests.py
@@ -38,10 +38,10 @@ def create_room_waiting_8p():
     tournament_id = 4
     return RoomKey.create_room(room_type, table_id, match_id, tournament_id)
 
-def create_test_room_members_simple():
+def create_test_room_members_simple(room_table_id):
     user = create_test_user('z', 'z', 'z', 'z', 'z')
-    create_room_simple(1)
-    return RoomMembers.objects.create(room_id = 'room:SIMPLE:1', user = user)
+    room_id = create_room_simple(room_table_id)
+    return RoomMembers.objects.create(room_id = room_id, user = user)
 
 def create_test_room_members_4():
     users = create_test_user_4()

--- a/api/conf/room/utils.py
+++ b/api/conf/room/utils.py
@@ -51,6 +51,12 @@ class RoomKey:
         return redis_client.hincrby(key, "entry_count", 1)
 
     @staticmethod
+    def decrement_entry_count(room_type: str, table_id: int) -> int:
+        redis_client = get_redis()
+        key = RoomKey.generate_key(room_type, table_id)
+        return redis_client.hincrby(key, "entry_count", -1)
+
+    @staticmethod
     def get_keys_by_type_and_entry_count(room_type: str, entry_count: int) -> list:
         redis_client = get_redis()
         keys_by_room = redis_client.keys(f"room:{room_type}:*")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,8 +106,8 @@ paths:
             example:
               type: remote
       responses:
-        "200":
-          description: ROOMの情報
+        "201":
+          description: ルーム作成成功
           content:
             application/json:
               schema:
@@ -124,6 +124,57 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/error_response"
+
+  /api/simple-matches/join:
+    post:
+      tags:
+        - simple_play
+      summary: 対戦待ちルームへの参加
+      description: |
+        リクエストのbodyに、`match_id` を含めて、指定された対戦待ちルームに参加します。
+        JWT認証が必要です。レスポンスには、ゲーム画面への遷移に必要な `match_id` を含みます。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                match_id:
+                  type: integer
+                  description: 参加する対戦待ちのMatchID
+              required:
+                - match_id
+            example:
+              match_id: 12345
+      responses:
+        "201":
+          description: 参加成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  match_id:
+                    type: integer
+                    description: ゲーム画面のURIの一部として使用されるマッチID
+              example:
+                match_id: 12345
+        "401":
+          description: 認証エラー(JWTトークンが無効または未提供)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_response"
+        "400":
+          description: リクエストエラー(無効なmatch_id)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error_response"
+
 
   /api/auth/login:
     post:


### PR DESCRIPTION
<!-- github copilotへ コードレビューの指示：レビューは必ず日本語で絵文字多めで楽しそうな感じで実施してください💐  -->
# レビュー方法
主なもの

- [x] openapi.yamlの記述がmiroと同じであること（エンドポイントURIとレスポンスデータの内容）
- [x] ~.yamlとmatch/test.pyの要求するデータ内容が同じであること
- [x] post(join)のビジネスロジックがmiroと同じであること
- [x] ルートディレクトリでmakeして、その他の動作に失敗がないこと

# 注意点
Djangoに記述されているテストケースは、GitHubアクションズで自動実行されるようになりました
