### PR TITLE
fix: SVGレンダリング最適化による要素キャッシュ実装

### DIFF
--- a/static-builder/src/js/pages/TournamentsBracket.js
+++ b/static-builder/src/js/pages/TournamentsBracket.js
@@ -50,14 +50,25 @@ export const TournamentsBracket = () => {
     )
   }
 
+  // SVG要素のキャッシュとメモ化
+  const participantBoardCache = new Map()
+  
   function createParticipantBoard(participant, x, y) {
+    const cacheKey = `${participant.player.name}-${x}-${y}-${participant.next_player}`
+    
+    // キャッシュにあれば再利用
+    if (participantBoardCache.has(cacheKey)) {
+      return participantBoardCache.get(cacheKey)
+    }
+    
     const xAdjustment = 5
     const yAdjustment = 12
     const textWidth = 110
     const textHeight = 20
     const fighterColor = '#FCAA30'
     const otherColor = '#182F44'
-    return [
+    
+    const elements = [
       Teact.createElement('rect', {
         x: x - xAdjustment,
         y: y - yAdjustment,
@@ -80,6 +91,13 @@ export const TournamentsBracket = () => {
         participant.player.name,
       ),
     ]
+    
+    // キャッシュに保存（最大100要素まで）
+    if (participantBoardCache.size < 100) {
+      participantBoardCache.set(cacheKey, elements)
+    }
+    
+    return elements
   }
 
   function createChampionParticipantBoard(participants, tournamentEnd) {


### PR DESCRIPTION
## 背景

トーナメントブラケット表示で以下のパフォーマンス問題が発生している：

### 問題点
1. **重複するSVG要素の生成**
   - 同じ参加者情報で`createParticipantBoard()`が繰り返し呼ばれる
   - 毎回新しいDOM要素（rect、text）を生成

2. **参加者数に比例する計算負荷**
   - トーナメント参加者が増えるたびに要素生成コストが線形増加
   - ブラウザの描画パフォーマンスに影響

## 修正内容

### メモ化キャッシュの実装
```javascript
const participantBoardCache = new Map()

function createParticipantBoard(participant, x, y) {
  const cacheKey = `${participant.player.name}-${x}-${y}-${participant.next_player}`
  
  // キャッシュにあれば再利用
  if (participantBoardCache.has(cacheKey)) {
    return participantBoardCache.get(cacheKey)
  }
  
  // 新規作成
  const elements = [/* SVG要素生成 */]
  
  // キャッシュに保存（最大100要素まで）
  if (participantBoardCache.size < 100) {
    participantBoardCache.set(cacheKey, elements)
  }
  
  return elements
}
```

### キャッシュキー設計
- プレイヤー名、座標（x,y）、状態（next_player）を組み合わせ
- 同じ条件の要素は再利用、状態変化時は新規生成

### メモリ管理
- キャッシュサイズを100要素に制限
- メモリリークを防止

## パフォーマンス改善

- **DOM要素生成**: 重複計算を削減
- **レンダリング速度**: 大規模トーナメントでの改善
- **メモリ効率**: 適切なキャッシュサイズ制限

## テスト計画

- [ ] トーナメント表示の正常動作確認
- [ ] キャッシュヒット率の測定
- [ ] 大人数トーナメントでのパフォーマステスト
- [ ] メモリ使用量の監視
- [ ] 状態変化時の正しい要素更新確認

🤖 Generated with [Claude Code](https://claude.ai/code)